### PR TITLE
Draft for LoopKit PR: add Silent Pod, Pod Diagnostic features and support

### DIFF
--- a/OmniKit.xcodeproj/project.pbxproj
+++ b/OmniKit.xcodeproj/project.pbxproj
@@ -191,6 +191,15 @@
 		D80339982A50085C004FF953 /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12EDA0329C7DDC800435701 /* TimeInterval.swift */; };
 		D803399A2A500D3D004FF953 /* CRC8.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12401B229C7D8E900B32844 /* CRC8.swift */; };
 		D803399B2A50122F004FF953 /* Packet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12401B329C7D8E900B32844 /* Packet.swift */; };
+		D845A1352AF89DEC00EA0853 /* SilencePodPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1342AF89DEC00EA0853 /* SilencePodPreference.swift */; };
+		D845A1462AF8A4DA00EA0853 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1452AF8A4DA00EA0853 /* ActivityView.swift */; };
+		D845A1482AF8A4E400EA0853 /* FirstAppear.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1472AF8A4E400EA0853 /* FirstAppear.swift */; };
+		D845A14A2AF8A4EF00EA0853 /* PlayTestBeepsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1492AF8A4EF00EA0853 /* PlayTestBeepsView.swift */; };
+		D845A14E2AF8A4FB00EA0853 /* ReadPodStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A14B2AF8A4FB00EA0853 /* ReadPodStatusView.swift */; };
+		D845A1502AF8A4FB00EA0853 /* PumpManagerDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A14D2AF8A4FB00EA0853 /* PumpManagerDetailsView.swift */; };
+		D845A1522AF8A51000EA0853 /* SilencePodSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D845A1512AF8A51000EA0853 /* SilencePodSelectionView.swift */; };
+		D85AEAC82B1403C000081044 /* PodDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEAC72B1403C000081044 /* PodDiagnostics.swift */; };
+		D85AEACA2B1403CB00081044 /* ReadPodInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85AEAC92B1403CB00081044 /* ReadPodInfoView.swift */; };
 		D803399C2A50128D004FF953 /* LocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12EDA0129C7DD4700435701 /* LocalizedString.swift */; };
 /* End PBXBuildFile section */
 
@@ -435,6 +444,15 @@
 		C12EDA1529C7DFF100435701 /* HKUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HKUnit.swift; sourceTree = "<group>"; };
 		C12EDA1729C7E01800435701 /* TimeZone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZone.swift; sourceTree = "<group>"; };
 		C12EDA1A29C7E06900435701 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
+		D845A1342AF89DEC00EA0853 /* SilencePodPreference.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SilencePodPreference.swift; sourceTree = "<group>"; };
+		D845A1452AF8A4DA00EA0853 /* ActivityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		D845A1472AF8A4E400EA0853 /* FirstAppear.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstAppear.swift; sourceTree = "<group>"; };
+		D845A1492AF8A4EF00EA0853 /* PlayTestBeepsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayTestBeepsView.swift; sourceTree = "<group>"; };
+		D845A14B2AF8A4FB00EA0853 /* ReadPodStatusView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadPodStatusView.swift; sourceTree = "<group>"; };
+		D845A14D2AF8A4FB00EA0853 /* PumpManagerDetailsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PumpManagerDetailsView.swift; sourceTree = "<group>"; };
+		D845A1512AF8A51000EA0853 /* SilencePodSelectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SilencePodSelectionView.swift; sourceTree = "<group>"; };
+		D85AEAC72B1403C000081044 /* PodDiagnostics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PodDiagnostics.swift; sourceTree = "<group>"; };
+		D85AEAC92B1403CB00081044 /* ReadPodInfoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadPodInfoView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -568,6 +586,7 @@
 				C12401A429C7D8E900B32844 /* CRC16.swift */,
 				C12401A529C7D8E900B32844 /* BasalSchedule.swift */,
 				C12401A629C7D8E900B32844 /* BolusDeliveryTable.swift */,
+				D845A1342AF89DEC00EA0853 /* SilencePodPreference.swift */,
 				C12401A729C7D8E900B32844 /* UnfinalizedDose.swift */,
 			);
 			path = OmnipodCommon;
@@ -712,6 +731,7 @@
 		C124022D29C7DA9700B32844 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				D845A1452AF8A4DA00EA0853 /* ActivityView.swift */,
 				C124024629C7DA9700B32844 /* AttachPodView.swift */,
 				C124024C29C7DA9700B32844 /* BasalStateView.swift */,
 				C124024429C7DA9700B32844 /* BeepPreferenceSelectionView.swift */,
@@ -721,6 +741,7 @@
 				C124023129C7DA9700B32844 /* DesignElements */,
 				C124023A29C7DA9700B32844 /* ExpirationReminderPickerView.swift */,
 				C124024529C7DA9700B32844 /* ExpirationReminderSetupView.swift */,
+				D845A1472AF8A4E400EA0853 /* FirstAppear.swift */,
 				C124023629C7DA9700B32844 /* InsertCannulaView.swift */,
 				C124023C29C7DA9700B32844 /* InsulinTypeConfirmation.swift */,
 				C124023529C7DA9700B32844 /* LowReservoirReminderEditView.swift */,
@@ -730,11 +751,17 @@
 				C124024929C7DA9700B32844 /* OmnipodReservoirView.swift */,
 				C124024029C7DA9700B32844 /* OmnipodSettingsView.swift */,
 				C124024329C7DA9700B32844 /* PairPodView.swift */,
+				D845A1492AF8A4EF00EA0853 /* PlayTestBeepsView.swift */,
 				C124024829C7DA9700B32844 /* PodDetailsView.swift */,
+				D85AEAC72B1403C000081044 /* PodDiagnostics.swift */,
 				C124024129C7DA9700B32844 /* PodSetupView.swift */,
+				D845A14D2AF8A4FB00EA0853 /* PumpManagerDetailsView.swift */,
+				D85AEAC92B1403CB00081044 /* ReadPodInfoView.swift */,
+				D845A14B2AF8A4FB00EA0853 /* ReadPodStatusView.swift */,
 				C124023729C7DA9700B32844 /* RileyLinkSetupView.swift */,
 				C124024729C7DA9700B32844 /* ScheduledExpirationReminderEditView.swift */,
 				C124023829C7DA9700B32844 /* SetupCompleteView.swift */,
+				D845A1512AF8A51000EA0853 /* SilencePodSelectionView.swift */,
 				C124024D29C7DA9700B32844 /* TimeView.swift */,
 				C124023B29C7DA9700B32844 /* UncertaintyRecoveredView.swift */,
 			);
@@ -1117,6 +1144,7 @@
 				C12401E429C7D8E900B32844 /* DetailedStatus+OmniKit.swift in Sources */,
 				C12401C929C7D8E900B32844 /* AssignAddressCommand.swift in Sources */,
 				C12401C429C7D8E900B32844 /* PodInfoPulseLogPlus.swift in Sources */,
+				D845A1352AF89DEC00EA0853 /* SilencePodPreference.swift in Sources */,
 				C12401CD29C7D8E900B32844 /* DetailedStatus.swift in Sources */,
 				C12401DF29C7D8E900B32844 /* BasalSchedule.swift in Sources */,
 				C12401DC29C7D8E900B32844 /* InsulinTableEntry.swift in Sources */,
@@ -1184,11 +1212,13 @@
 				C124028D29C7DA9700B32844 /* AttachPodView.swift in Sources */,
 				C124027229C7DA9700B32844 /* DeactivatePodViewModel.swift in Sources */,
 				C124028C29C7DA9700B32844 /* ExpirationReminderSetupView.swift in Sources */,
+				D845A1462AF8A4DA00EA0853 /* ActivityView.swift in Sources */,
 				C124029029C7DA9700B32844 /* OmnipodReservoirView.swift in Sources */,
 				C124027C29C7DA9700B32844 /* LowReservoirReminderEditView.swift in Sources */,
 				C124028129C7DA9700B32844 /* ExpirationReminderPickerView.swift in Sources */,
 				C124028329C7DA9700B32844 /* InsulinTypeConfirmation.swift in Sources */,
 				C124029129C7DA9700B32844 /* DeliveryUncertaintyRecoveryView.swift in Sources */,
+				D845A1502AF8A4FB00EA0853 /* PumpManagerDetailsView.swift in Sources */,
 				C124028229C7DA9700B32844 /* UncertaintyRecoveredView.swift in Sources */,
 				C124027E29C7DA9700B32844 /* RileyLinkSetupView.swift in Sources */,
 				C124027429C7DA9700B32844 /* PodLifeState.swift in Sources */,
@@ -1196,10 +1226,13 @@
 				C124027329C7DA9700B32844 /* RileyLinkListDataSource.swift in Sources */,
 				C124029329C7DA9700B32844 /* BasalStateView.swift in Sources */,
 				C124027A29C7DA9700B32844 /* LeadingImage.swift in Sources */,
+				D845A14E2AF8A4FB00EA0853 /* ReadPodStatusView.swift in Sources */,
 				C124028729C7DA9700B32844 /* OmnipodSettingsView.swift in Sources */,
 				C124028929C7DA9700B32844 /* LowReservoirReminderSetupView.swift in Sources */,
 				C124027029C7DA9700B32844 /* DeliveryUncertaintyRecoveryViewModel.swift in Sources */,
 				C12EDA0E29C7DEFD00435701 /* NumberFormatter.swift in Sources */,
+				D845A1522AF8A51000EA0853 /* SilencePodSelectionView.swift in Sources */,
+				D845A1482AF8A4E400EA0853 /* FirstAppear.swift in Sources */,
 				C12EDA1229C7DF4B00435701 /* IdentifiableClass.swift in Sources */,
 				C124027529C7DA9700B32844 /* OmnipodSettingsViewModel.swift in Sources */,
 				C124029729C7DA9700B32844 /* OmnipodUICoordinator.swift in Sources */,
@@ -1210,8 +1243,10 @@
 				C124028A29C7DA9700B32844 /* PairPodView.swift in Sources */,
 				C124029229C7DA9700B32844 /* DeactivatePodView.swift in Sources */,
 				C124027929C7DA9700B32844 /* RoundedCard.swift in Sources */,
+				D845A14A2AF8A4EF00EA0853 /* PlayTestBeepsView.swift in Sources */,
 				C124026F29C7DA9700B32844 /* PairPodViewModel.swift in Sources */,
 				C124026E29C7DA9700B32844 /* FrameworkLocalText.swift in Sources */,
+				D85AEAC82B1403C000081044 /* PodDiagnostics.swift in Sources */,
 				C124028F29C7DA9700B32844 /* PodDetailsView.swift in Sources */,
 				C124028629C7DA9700B32844 /* NotificationSettingsView.swift in Sources */,
 				C124027D29C7DA9700B32844 /* InsertCannulaView.swift in Sources */,
@@ -1224,6 +1259,7 @@
 				C124027B29C7DA9700B32844 /* ErrorView.swift in Sources */,
 				C124028829C7DA9700B32844 /* PodSetupView.swift in Sources */,
 				C124027F29C7DA9700B32844 /* SetupCompleteView.swift in Sources */,
+				D85AEACA2B1403CB00081044 /* ReadPodInfoView.swift in Sources */,
 				C124029429C7DA9700B32844 /* TimeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/OmniKit/OmnipodCommon/AlertSlot.swift
+++ b/OmniKit/OmnipodCommon/AlertSlot.swift
@@ -8,9 +8,27 @@
 
 import Foundation
 
+fileprivate let defaultShutdownImminentTime = Pod.serviceDuration - Pod.endOfServiceImminentWindow
+fileprivate let defaultExpirationReminderTime = Pod.nominalPodLife - Pod.defaultExpirationReminderOffset
+fileprivate let defaultExpiredTime = Pod.nominalPodLife
+
+// PDM and pre-SwiftUI use every1MinuteFor3MinutesAndRepeatEvery15Minutes, but with SwiftUI use every15Minutes
+fileprivate let suspendTimeExpiredBeepRepeat = BeepRepeat.every15Minutes
+
 public enum AlertTrigger {
     case unitsRemaining(Double)
     case timeUntilAlert(TimeInterval)
+}
+
+extension AlertTrigger: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .unitsRemaining(let units):
+            return "\(Int(units))U"
+        case .timeUntilAlert(let triggerTime):
+            return "triggerTime=\(triggerTime.timeIntervalStr)"
+        }
+    }
 }
 
 public enum BeepRepeat: UInt8 {
@@ -29,29 +47,48 @@ public enum BeepRepeat: UInt8 {
 public struct AlertConfiguration {
 
     let slot: AlertSlot
-    let trigger: AlertTrigger
     let active: Bool
     let duration: TimeInterval
+    let trigger: AlertTrigger
     let beepRepeat: BeepRepeat
     let beepType: BeepType
+    let silent: Bool
     let autoOffModifier: Bool
 
     static let length = 6
 
-    public init(alertType: AlertSlot, active: Bool = true, autoOffModifier: Bool = false, duration: TimeInterval, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType) {
+    public init(alertType: AlertSlot, active: Bool = true, duration: TimeInterval = 0, trigger: AlertTrigger, beepRepeat: BeepRepeat, beepType: BeepType, silent: Bool, autoOffModifier: Bool = false)
+    {
         self.slot = alertType
         self.active = active
-        self.autoOffModifier = autoOffModifier
         self.duration = duration
         self.trigger = trigger
         self.beepRepeat = beepRepeat
         self.beepType = beepType
+        self.silent = silent
+        self.autoOffModifier = autoOffModifier
     }
 }
 
 extension AlertConfiguration: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "AlertConfiguration(slot:\(slot), active:\(active), autoOffModifier:\(autoOffModifier), duration:\(duration), trigger:\(trigger), beepRepeat:\(beepRepeat), beepType:\(beepType))"
+        var str = "slot:\(slot)"
+        if !active {
+            str += ", active:\(active)"
+        }
+        if duration != 0 {
+            str += ", duration:\(duration.timeIntervalStr)"
+        }
+        str += ", trigger:\(trigger), beepRepeat:\(beepRepeat)"
+        if beepType != .noBeepNonCancel {
+            str += ", beepType:\(beepType)"
+        } else {
+            str += ", silent:\(silent)"
+        }
+        if autoOffModifier {
+            str += ", autoOffModifier:\(autoOffModifier)"
+        }
+        return "\nAlertConfiguration(\(str))"
     }
 }
 
@@ -60,54 +97,73 @@ extension AlertConfiguration: CustomDebugStringConvertible {
 public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
     public typealias RawValue = [String: Any]
 
-    // 2 hours long, time for user to start pairing process
+    // slot0AutoOff: auto-off timer; requires user input every x minutes -- NOT IMPLEMENTED
+    case autoOff(active: Bool, offset: TimeInterval, countdownDuration: TimeInterval, silent: Bool = false)
+
+    // slot1NotUsed
+    case notUsed
+
+    // slot2ShutdownImminent: 79 hour alarm (1 hour before shutdown)
+    // 2 sets of beeps every 15 minutes for 1 hour
+    case shutdownImminent(offset: TimeInterval, absAlertTime: TimeInterval, silent: Bool = false)
+
+    // slot3ExpirationReminder: User configurable with PDM (1-24 hours before 72 hour expiration)
+    // 2 sets of beeps every minute for 3 minutes and repeat every 15 minutes
+    // The PDM doesn't use a duration for this alert (presumably because it is limited to 2^9-1 minutes or 8h31m)
+    case expirationReminder(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval = 0, silent: Bool = false)
+
+    // slot4LowReservoir: reservoir below configured value alert
+    case lowReservoir(units: Double, silent: Bool = false)
+
+    // slot5SuspendedReminder: pod suspended reminder, before suspendTime;
+    // short beep every 15 minutes if > 30 min, else short beep every 5 minutes
+    case podSuspendedReminder(active: Bool, offset: TimeInterval, suspendTime: TimeInterval, timePassed: TimeInterval = 0, silent: Bool = false)
+
+    // slot6SuspendTimeExpired: pod suspend time expired alarm, after suspendTime;
+    // 2 sets of beeps every minute for 3 minutes repeated every 15 minutes (PDM & pre-SwiftUI implementations)
+    // 2 sets of beeps every 15 minutes (for SwiftUI PumpManagerAlerts implementations)
+    case suspendTimeExpired(offset: TimeInterval, suspendTime: TimeInterval, silent: Bool = false)
+
+    // slot7Expired: 2 hours long, time for user to start pairing process
     case waitingForPairingReminder
 
-    // 1 hour long, time for user to finish priming, cannula insertion
+    // slot7Expired: 1 hour long, time for user to finish priming, cannula insertion
     case finishSetupReminder
 
-    // User configurable with PDM (1-24 hours before 72 hour expiration) "Change Pod Soon"
-    case expirationReminder(TimeInterval)
-
-    // 72 hour alarm
-    case expired(alertTime: TimeInterval, duration: TimeInterval)
-
-    // 79 hour alarm (1 hour before shutdown)
-    case shutdownImminent(TimeInterval)
-
-    // reservoir below configured value alert
-    case lowReservoir(Double)
-
-    // auto-off timer; requires user input every x minutes
-    case autoOff(active: Bool, countdownDuration: TimeInterval)
-
-    // pod suspended reminder, before suspendTime; short beep every 15 minutes if > 30 min, else every 5 minutes
-    case podSuspendedReminder(active: Bool, suspendTime: TimeInterval)
-
-    // pod suspend time expired alarm, after suspendTime; 2 sets of beeps every min for 3 minutes repeated every 15 minutes
-    case suspendTimeExpired(suspendTime: TimeInterval)
+    // slot7Expired: 72 hour alarm
+    case expired(offset: TimeInterval, absAlertTime: TimeInterval, duration: TimeInterval, silent: Bool = false)
 
     public var description: String {
         var alertName: String
         switch self {
-        case .waitingForPairingReminder:
-            return LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder")
-        case .finishSetupReminder:
-            return LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder")
-        case .expirationReminder:
-            alertName = LocalizedString("Expiration alert", comment: "Description for expiration alert")
-        case .expired:
-            alertName = LocalizedString("Expiration advisory", comment: "Description for expiration advisory")
-        case .shutdownImminent:
-            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent")
-        case .lowReservoir(let units):
-            alertName = String(format: LocalizedString("Low reservoir advisory (%1$gU)", comment: "Format string for description for low reservoir advisory (1: reminder units)"), units)
+        // slot0AutoOff
         case .autoOff:
-            alertName = LocalizedString("Auto-off", comment: "Description for auto-off")
+            alertName = LocalizedString("Auto-off", comment: "Description for auto-off alert")
+        // slot1NotUsed
+        case .notUsed:
+            alertName = LocalizedString("Not used", comment: "Description for not used slot alert")
+        // slot2ShutdownImminent
+        case .shutdownImminent:
+            alertName = LocalizedString("Shutdown imminent", comment: "Description for shutdown imminent alert")
+        // slot3ExpirationReminder
+        case .expirationReminder:
+            alertName = LocalizedString("Expiration reminder", comment: "Description for expiration reminder alert")
+        // slot4LowReservoir
+        case .lowReservoir:
+            alertName = LocalizedString("Low reservoir", comment: "Format string for description for low reservoir alert")
+        // slot5SuspendedReminder
         case .podSuspendedReminder:
-            alertName = LocalizedString("Pod suspended reminder", comment: "Description for pod suspended reminder")
+            alertName = LocalizedString("Pod suspended reminder", comment: "Description for pod suspended reminder alert")
+        // slot6SuspendTimeExpired
         case .suspendTimeExpired:
-            alertName = LocalizedString("Suspend time expired", comment: "Description for suspend time expired")
+            alertName = LocalizedString("Suspend time expired", comment: "Description for suspend time expired alert")
+        // slot7Expired
+        case .waitingForPairingReminder:
+            alertName = LocalizedString("Waiting for pairing reminder", comment: "Description waiting for pairing reminder alert")
+        case .finishSetupReminder:
+            alertName = LocalizedString("Finish setup reminder", comment: "Description for finish setup reminder alert")
+        case .expired:
+            alertName = LocalizedString("Pod expired", comment: "Description for pod expired alert")
         }
         if self.configuration.active == false {
             alertName += LocalizedString(" (inactive)", comment: "Description for an inactive alert modifier")
@@ -117,71 +173,126 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
     public var configuration: AlertConfiguration {
         switch self {
-        case .waitingForPairingReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(110), trigger: .timeUntilAlert(.minutes(10)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .finishSetupReminder:
-            return AlertConfiguration(alertType: .slot7, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expirationReminder(let alertTime):
-            let active = alertTime != 0 // disable if alertTime is 0
-            return AlertConfiguration(alertType: .slot3, active: active, duration: 0, trigger: .timeUntilAlert(alertTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .expired(let alarmTime, let duration):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot7, active: active, duration: duration, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .shutdownImminent(let alarmTime):
-            let active = alarmTime != 0 // disable if alarmTime is 0
-            return AlertConfiguration(alertType: .slot2, active: active, duration: 0, trigger: .timeUntilAlert(alarmTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .lowReservoir(let units):
-            let active = units != 0 // disable if units is 0
-            return AlertConfiguration(alertType: .slot4, active: active, duration: 0, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .autoOff(let active, let countdownDuration):
-            return AlertConfiguration(alertType: .slot0, active: active, autoOffModifier: true, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep)
-        case .podSuspendedReminder(let active, let suspendTime):
-            // A suspendTime of 0 is an untimed suspend
-            let reminderInterval, duration: TimeInterval
-            let trigger: AlertTrigger
-            let beepRepeat: BeepRepeat
-            let beepType: BeepType
+        // slot0AutoOff
+        case .autoOff(let active, _, let countdownDuration, let silent):
+            return AlertConfiguration(alertType: .slot0AutoOff, active: active, duration: .minutes(15), trigger: .timeUntilAlert(countdownDuration), beepRepeat: .every1MinuteFor15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent, autoOffModifier: true)
+
+        // slot1NotUsed
+        case .notUsed:
+            return AlertConfiguration(alertType: .slot1NotUsed, duration: .minutes(55), trigger: .timeUntilAlert(.minutes(5)), beepRepeat: .every5Minutes, beepType: .noBeepNonCancel, silent: false)
+
+        // slot2ShutdownImminent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
             if active {
-                if suspendTime >= TimeInterval(minutes :30) {
-                    // Use 15-minute pod suspended reminder beeps for longer scheduled suspend times as per PDM.
-                    reminderInterval = TimeInterval(minutes: 15)
-                    beepRepeat = .every15Minutes
-                } else {
-                    // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
-                    reminderInterval = TimeInterval(minutes: 5)
-                    beepRepeat = .every5Minutes
-                }
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot2ShutdownImminent, active: active, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot3ExpirationReminder
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = 0
+            }
+            return AlertConfiguration(alertType: .slot3ExpirationReminder, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery15Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot4LowReservoir
+        case .lowReservoir(let units, let silent):
+            let active = units != 0 // disable if units is 0
+            return AlertConfiguration(alertType: .slot4LowReservoir, active: active, trigger: .unitsRemaining(units), beepRepeat: .every1MinuteFor3MinutesAndRepeatEvery60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
+
+        // slot5SuspendedReminder
+        // A suspendTime of 0 is an untimed suspend
+        // timePassed will be > 0 for an existing pod suspended reminder changing its silent state
+        case .podSuspendedReminder(let active, _, let suspendTime, let timePassed, let silent):
+            let reminderInterval, duration: TimeInterval
+            var beepRepeat: BeepRepeat
+            let beepType: BeepType
+            let trigger: AlertTrigger
+            var isActive: Bool = active
+
+            if suspendTime == 0 || suspendTime >= TimeInterval(minutes: 30) {
+                // Use 15-minute pod suspended reminder beeps for untimed or longer scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 15)
+                beepRepeat = .every15Minutes
+            } else {
+                // Use 5-minute pod suspended reminder beeps for shorter scheduled suspend times.
+                reminderInterval = TimeInterval(minutes: 5)
+                beepRepeat = .every5Minutes
+            }
+
+            // Make alert inactive if there isn't enough remaining in suspend time for a reminder beep.
+            let suspendTimeRemaining = suspendTime - timePassed
+            if suspendTime != 0 && suspendTimeRemaining <= reminderInterval {
+                isActive = false
+            }
+
+            if isActive {
+                // Compute the alert trigger time as the interval until the next upcoming reminder interval
+                let triggerTime: TimeInterval = .seconds(reminderInterval - Double((Int(timePassed) % Int(reminderInterval))))
+
                 if suspendTime == 0 {
                     duration = 0 // Untimed suspend, no duration
-                } else if suspendTime > reminderInterval {
-                    duration = suspendTime - reminderInterval // End after suspendTime total time
                 } else {
-                    duration = .minutes(1) // Degenerate case, end ASAP
+                    // duration is from triggerTime to suspend time remaining
+                    duration = suspendTimeRemaining - triggerTime
                 }
-                trigger = .timeUntilAlert(reminderInterval) // Start after reminderInterval has passed
+                trigger = .timeUntilAlert(triggerTime) // time to next reminder interval with the suspend time
                 beepType = .beep
             } else {
+                beepRepeat = .once
                 duration = 0
                 trigger = .timeUntilAlert(.minutes(0))
-                beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot5, active: active, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
-        case .suspendTimeExpired(let suspendTime):
+            return AlertConfiguration(alertType: .slot5SuspendedReminder, active: isActive, duration: duration, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot6SuspendTimeExpired
+        case .suspendTimeExpired(_, let suspendTime, let silent):
             let active = suspendTime != 0 // disable if suspendTime is 0
             let trigger: AlertTrigger
             let beepRepeat: BeepRepeat
             let beepType: BeepType
             if active {
                 trigger = .timeUntilAlert(suspendTime)
-                beepRepeat = .every1MinuteFor3MinutesAndRepeatEvery15Minutes
+                beepRepeat = suspendTimeExpiredBeepRepeat
                 beepType = .bipBeepBipBeepBipBeepBipBeep
             } else {
                 trigger = .timeUntilAlert(.minutes(0))
                 beepRepeat = .once
                 beepType = .noBeepCancel
             }
-            return AlertConfiguration(alertType: .slot6, active: active, duration: 0, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType)
+            return AlertConfiguration(alertType: .slot6SuspendTimeExpired, active: active, trigger: trigger, beepRepeat: beepRepeat, beepType: beepType, silent: silent)
+
+        // slot7Expired
+        case .waitingForPairingReminder:
+            // After pod is powered up, beep every 10 minutes for up to 2 hours before pairing before failing
+            let totalDuration: TimeInterval = .hours(2)
+            let startOffset: TimeInterval = .minutes(10)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
+        case .finishSetupReminder:
+            // After pod is paired, beep every 5 minutes for up to 1 hour for pod setup to complete before failing
+            let totalDuration: TimeInterval = .hours(1)
+            let startOffset: TimeInterval = .minutes(5)
+            return AlertConfiguration(alertType: .slot7Expired, duration: totalDuration - startOffset, trigger: .timeUntilAlert(startOffset), beepRepeat: .every5Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: false)
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            // Normally used to alert at Pod.nominalPodLife (72 hours) for Pod.expirationAdvisoryWindow (7 hours)
+            // 2 sets of beeps repeating every 60 minutes
+            let active = absAlertTime != 0 // disable if absAlertTime is 0
+            let triggerTime: TimeInterval
+            if active {
+                triggerTime = absAlertTime - offset
+            } else {
+                triggerTime = .minutes(0)
+            }
+            return AlertConfiguration(alertType: .slot7Expired, active: active, duration: duration, trigger: .timeUntilAlert(triggerTime), beepRepeat: .every60Minutes, beepType: .bipBeepBipBeepBipBeepBipBeep, silent: silent)
         }
     }
 
@@ -194,51 +305,92 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
         }
 
         switch name {
-        case "waitingForPairingReminder":
-            self = .waitingForPairingReminder
-        case "finishSetupReminder":
-            self = .finishSetupReminder
-        case "expirationReminder":
-            guard let alertTime = rawValue["alertTime"] as? Double else {
-                return nil
-            }
-            self = .expirationReminder(TimeInterval(alertTime))
-        case "expired":
-            guard let alarmTime = rawValue["alarmTime"] as? Double,
-                let duration = rawValue["duration"] as? Double else
+        case "autoOff":
+            guard let active = rawValue["active"] as? Bool,
+                let countdownDuration = rawValue["countdownDuration"] as? TimeInterval else
             {
                 return nil
             }
-            self = .expired(alertTime: TimeInterval(alarmTime), duration: TimeInterval(duration))
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .autoOff(active: active, offset: offset, countdownDuration: countdownDuration, silent: silent)
         case "shutdownImminent":
-            guard let alarmTime = rawValue["alarmTime"] as? Double else {
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval else {
                 return nil
             }
-            self = .shutdownImminent(alarmTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultShutdownImminentTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .shutdownImminent(offset: offsetToUse, absAlertTime: absAlertTime, silent: silent)
+        case "expirationReminder":
+            guard let alertTime = rawValue["alertTime"] as? TimeInterval else {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpirationReminderTime
+                offsetToUse = absAlertTime - alertTime
+            } else {
+                absAlertTime = offset + alertTime
+                offsetToUse = offset
+            }
+            let duration = rawValue["duration"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expirationReminder(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration,  silent: silent)
         case "lowReservoir":
             guard let units = rawValue["units"] as? Double else {
                 return nil
             }
-            self = .lowReservoir(units)
-        case "autoOff":
-            guard let active = rawValue["active"] as? Bool,
-                let countdownDuration = rawValue["countdownDuration"] as? Double else
-            {
-                return nil
-            }
-            self = .autoOff(active: active, countdownDuration: TimeInterval(countdownDuration))
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .lowReservoir(units: units, silent: silent)
         case "podSuspendedReminder":
             guard let active = rawValue["active"] as? Bool,
-                let suspendTime = rawValue["suspendTime"] as? Double else
+                let suspendTime = rawValue["suspendTime"] as? TimeInterval else
             {
                 return nil
             }
-            self = .podSuspendedReminder(active: active, suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, silent: silent)
         case "suspendTimeExpired":
             guard let suspendTime = rawValue["suspendTime"] as? Double else {
                 return nil
             }
-            self = .suspendTimeExpired(suspendTime: suspendTime)
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .suspendTimeExpired(offset: offset, suspendTime: suspendTime, silent: silent)
+        case "waitingForPairingReminder":
+            self = .waitingForPairingReminder
+        case "finishSetupReminder":
+            self = .finishSetupReminder
+        case "expired":
+            guard let alarmTime = rawValue["alarmTime"] as? TimeInterval,
+                let duration = rawValue["duration"] as? TimeInterval else
+            {
+                return nil
+            }
+            let offset = rawValue["offset"] as? TimeInterval ?? 0
+            let offsetToUse, absAlertTime: TimeInterval
+            if offset == 0 {
+                // use default values as no offset value was found
+                absAlertTime = defaultExpiredTime
+                offsetToUse = absAlertTime - alarmTime
+            } else {
+                absAlertTime = offset + alarmTime
+                offsetToUse = offset
+            }
+            let silent = rawValue["silent"] as? Bool ?? false
+            self = .expired(offset: offsetToUse, absAlertTime: absAlertTime, duration: duration, silent: silent)
         default:
             return nil
         }
@@ -248,50 +400,65 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 
         let name: String = {
             switch self {
-            case .waitingForPairingReminder:
-                return "waitingForPairingReminder"
-            case .finishSetupReminder:
-                return "finishSetupReminder"
-            case .expirationReminder:
-                return "expirationReminder"
-            case .expired:
-                return "expired"
-            case .shutdownImminent:
-                return "shutdownImminent"
-            case .lowReservoir:
-                return "lowReservoir"
             case .autoOff:
                 return "autoOff"
+            case .notUsed:
+                return "notUsed"
+            case .shutdownImminent:
+                return "shutdownImminent"
+            case .expirationReminder:
+                return "expirationReminder"
+            case .lowReservoir:
+                return "lowReservoir"
             case .podSuspendedReminder:
                 return "podSuspendedReminder"
             case .suspendTimeExpired:
                 return "suspendTimeExpired"
+            case .waitingForPairingReminder:
+                return "waitingForPairingReminder"
+            case .finishSetupReminder:
+                return "finishSetupReminder"
+            case .expired:
+                return "expired"
             }
         }()
-
 
         var rawValue: RawValue = [
             "name": name,
         ]
 
         switch self {
-        case .expirationReminder(let alertTime):
-            rawValue["alertTime"] = alertTime
-        case .expired(let alarmTime, let duration):
-            rawValue["alarmTime"] = alarmTime
-            rawValue["duration"] = duration
-        case .shutdownImminent(let alarmTime):
-            rawValue["alarmTime"] = alarmTime
-        case .lowReservoir(let units):
-            rawValue["units"] = units
-        case .autoOff(let active, let countdownDuration):
+        case .autoOff(let active, let offset, let countdownDuration, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["countdownDuration"] = countdownDuration
-        case .podSuspendedReminder(let active, let suspendTime):
+            rawValue["silent"] = silent
+        case .shutdownImminent(let offset, let absAlertTime, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["silent"] = silent
+        case .expirationReminder(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alertTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
+        case .lowReservoir(let units, let silent):
+            rawValue["units"] = units
+            rawValue["silent"] = silent
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, let silent):
             rawValue["active"] = active
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
-        case .suspendTimeExpired(let suspendTime):
+            rawValue["silent"] = silent
+        case .suspendTimeExpired(let offset, let suspendTime, let silent):
+            rawValue["offset"] = offset
             rawValue["suspendTime"] = suspendTime
+            rawValue["silent"] = silent
+        case .expired(let offset, let absAlertTime, let duration, let silent):
+            rawValue["offset"] = offset
+            rawValue["alarmTime"] = absAlertTime - offset
+            rawValue["duration"] = duration
+            rawValue["silent"] = silent
         default:
             break
         }
@@ -301,14 +468,14 @@ public enum PodAlert: CustomStringConvertible, RawRepresentable, Equatable {
 }
 
 public enum AlertSlot: UInt8 {
-    case slot0 = 0x00
-    case slot1 = 0x01
-    case slot2 = 0x02
-    case slot3 = 0x03
-    case slot4 = 0x04
-    case slot5 = 0x05
-    case slot6 = 0x06
-    case slot7 = 0x07
+    case slot0AutoOff = 0x00
+    case slot1NotUsed = 0x01
+    case slot2ShutdownImminent = 0x02
+    case slot3ExpirationReminder = 0x03
+    case slot4LowReservoir = 0x04
+    case slot5SuspendedReminder = 0x05
+    case slot6SuspendTimeExpired = 0x06
+    case slot7Expired = 0x07
 
     public var bitMaskValue: UInt8 {
         return 1<<rawValue
@@ -373,9 +540,179 @@ public struct AlertSet: RawRepresentable, Collection, CustomStringConvertible, E
 
 // Returns true if there are any active suspend related alerts
 public func hasActiveSuspendAlert(configuredAlerts: [AlertSlot : PodAlert]) -> Bool {
-    // slot5 is for podSuspendedReminder and slot6 is for suspendTimeExpired
-    if configuredAlerts.contains(where: { ($0.key == .slot5 || $0.key == .slot6) && $0.value.configuration.active }) {
+    if configuredAlerts.contains(where: { ($0.key == .slot5SuspendedReminder || $0.key == .slot6SuspendTimeExpired) && $0.value.configuration.active })
+    {
         return true
     }
     return false
+}
+
+// Returns a descriptive string for all the alerts in alertSet
+public func alertSetString(alertSet: AlertSet) -> String {
+
+    if alertSet.isEmpty {
+        // Don't bother displaying any additional info for an inactive alert
+        return String(describing: alertSet)
+    }
+
+    let alertDescription = alertSet.map { (slot) -> String in
+        switch slot {
+        case .slot0AutoOff:
+            return PodAlert.autoOff(active: true, offset: 0, countdownDuration: 0).description
+        case .slot1NotUsed:
+            return PodAlert.notUsed.description
+        case .slot2ShutdownImminent:
+            return PodAlert.shutdownImminent(offset: 0, absAlertTime: defaultShutdownImminentTime).description
+        case .slot3ExpirationReminder:
+            return PodAlert.expirationReminder(offset: 0, absAlertTime: defaultExpirationReminderTime).description
+        case .slot4LowReservoir:
+            return PodAlert.lowReservoir(units: Pod.maximumReservoirReading).description
+        case .slot5SuspendedReminder:
+            return PodAlert.podSuspendedReminder(active: true, offset: 0, suspendTime: .minutes(30)).description
+        case .slot6SuspendTimeExpired:
+            return PodAlert.suspendTimeExpired(offset: 0, suspendTime: .minutes(30)).description
+        case .slot7Expired:
+            return PodAlert.expired(offset: 0, absAlertTime: defaultExpiredTime, duration: Pod.expirationAdvisoryWindow).description
+        }
+    }
+
+    return alertDescription.joined(separator: ", ")
+}
+
+func configuredAlertsString(configuredAlerts: [AlertSlot : PodAlert]) -> String {
+
+    if configuredAlerts.isEmpty {
+        return String(describing: configuredAlerts)
+    }
+
+    let configuredAlertString = configuredAlerts.map { (configuredAlert) -> String in
+
+        let podAlert = configuredAlert.value
+        let description = podAlert.description
+        guard podAlert.configuration.active else {
+            return description
+        }
+
+        switch podAlert {
+        case .shutdownImminent(_, let absAlertTime, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .expirationReminder(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        case .lowReservoir(let unitTrigger, _):
+            return String(format: "%@ @ %dU", description, Int(unitTrigger))
+        case .podSuspendedReminder(_, let offset, let suspendTime, _, _):
+            return String(format: "%@ ending @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .suspendTimeExpired(let offset, let suspendTime, _):
+            return String(format: "%@ @ %@ after %@", description, (offset + suspendTime).timeIntervalStr, suspendTime.timeIntervalStr)
+        case .expired(_, let absAlertTime, _, _):
+            return String(format: "%@ @ %@", description, absAlertTime.timeIntervalStr)
+        default:
+            return ""
+        }
+    }
+
+    return configuredAlertString.joined(separator: ", ")
+}
+
+// Returns an array of appropriate PodAlerts with the specified silent value
+// for all the configuredAlerts given all the current pod conditions.
+func regeneratePodAlerts(silent: Bool, configuredAlerts: [AlertSlot: PodAlert], activeAlertSlots: AlertSet, currentPodTime: TimeInterval, currentReservoirLevel: Double) -> [PodAlert] {
+    var podAlerts: [PodAlert] = []
+
+    for alert in configuredAlerts {
+        // Just skip this alert if not previously active
+        guard alert.value.configuration.active else {
+            continue
+        }
+
+        // Map alerts to corresponding appropriate new ones at the current pod time using the specified silent value.
+        switch alert.value {
+
+        case .shutdownImminent(let offset, let alertTime, _):
+            // alertTime is absolute when offset is non-zero, otherwise use  default value
+            var absAlertTime = offset != 0 ? alertTime : defaultShutdownImminentTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+            }
+            // create new shutdownImminent podAlert using the current timeActive and the original absolute alert time
+            podAlerts.append(PodAlert.shutdownImminent(offset: currentPodTime, absAlertTime: absAlertTime, silent: silent))
+
+        case .expirationReminder(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpirationReminderTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expirationReminder podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expirationReminder(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        case .lowReservoir(let unitTrigger, _):
+            let units: Double
+            if currentReservoirLevel > unitTrigger {
+                units = unitTrigger
+            } else {
+                // reservoir is no longer more than the unitTrigger, make inactive using a 0 value
+                units = 0
+            }
+            podAlerts.append(PodAlert.lowReservoir(units: units, silent: silent))
+
+        case .podSuspendedReminder(let active, let offset, let suspendTime, _, _):
+            let timePassed: TimeInterval = min(currentPodTime - offset, .hours(2))
+            // Pass along the computed time passed since alert was originally set so creation routine can
+            // do all the grunt work dealing with varying reminder intervals and time passing scenarios.
+            podAlerts.append(PodAlert.podSuspendedReminder(active: active, offset: offset, suspendTime: suspendTime, timePassed: timePassed, silent: silent))
+
+        case .suspendTimeExpired(let lastOffset, let lastSuspendTime, _):
+            let absAlertTime = lastOffset + lastSuspendTime
+            let suspendTime: TimeInterval
+            if currentPodTime >= absAlertTime {
+                // alert trigger is no longer in the future
+                if activeAlertSlots.contains(where: { $0 == .slot6SuspendTimeExpired } ) {
+                    // The suspendTimeExpired alert has yet been acknowledged,
+                    // set up a suspendTimeExpired alert for the next 15m interval.
+                    // Compute a new suspendTime that is a multiple of 15 minutes
+                    // from lastOffset which is at least one minute in the future.
+                    let newOffsetSuspendTime = ceil((currentPodTime - lastOffset) / .minutes(15)) * .minutes(15)
+                    let newAbsAlertTime = lastOffset + newOffsetSuspendTime
+                    suspendTime = max(newAbsAlertTime - currentPodTime, .minutes(1))
+                } else {
+                    // The suspendTimeExpired alert was already been acknowledged,
+                    // so now make this alert inactive by using a 0 suspendTime.
+                    suspendTime = 0
+                }
+            } else {
+                // recompute a new suspendTime based on the current pod time
+                suspendTime = absAlertTime - currentPodTime
+                print("setting new suspendTimeExpired suspendTime of \(suspendTime) with currentPodTime\(currentPodTime) and absAlertTime=\(absAlertTime)")
+            }
+            // create a new suspendTimeExpired PodAlert using the current active time and the computed suspendTime (if any)
+            podAlerts.append(PodAlert.suspendTimeExpired(offset: currentPodTime, suspendTime: suspendTime, silent: silent))
+
+        case .expired(let offset, let alertTime, let alertDuration, _):
+            let duration: TimeInterval
+
+            // alertTime is absolute when offset is non-zero, otherwise use default value
+            var absAlertTime = offset != 0 ? alertTime : defaultExpiredTime
+            if currentPodTime >= absAlertTime {
+                // alert trigger is not in the future, make inactive using a 0 value
+                absAlertTime = 0
+                duration = 0
+            } else {
+                duration = alertDuration
+            }
+            // create new expired podAlert using the current active time and the original absolute alert time and duration
+            podAlerts.append(PodAlert.expired(offset: currentPodTime, absAlertTime: absAlertTime, duration: duration, silent: silent))
+
+        default:
+            break
+        }
+    }
+    return podAlerts
 }

--- a/OmniKit/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
+++ b/OmniKit/OmnipodCommon/MessageBlocks/ConfigureAlertsCommand.swift
@@ -21,7 +21,9 @@ public struct ConfigureAlertsCommand : NonceResyncableMessageBlock {
             UInt8(4 + configurations.count * AlertConfiguration.length),
             ])
         data.appendBigEndian(nonce)
-        for config in configurations {
+        // Sorting the alerts not required, but it can be helpful for log analysis
+        let sorted = configurations.sorted { $0.slot.rawValue < $1.slot.rawValue }
+        for config in sorted {
             data.append(contentsOf: config.data)
         }
         return data
@@ -92,6 +94,7 @@ extension AlertConfiguration {
         }
         self.beepType = beepType
 
+        self.silent = (beepType == .noBeepNonCancel)
     }
 
     public var data: Data {
@@ -126,7 +129,8 @@ extension AlertConfiguration {
             data.appendBigEndian(minutes)
         }
         data.append(beepRepeat.rawValue)
-        data.append(beepType.rawValue)
+        let beepTypeToSet: BeepType = silent ? .noBeepNonCancel : beepType
+        data.append(beepTypeToSet.rawValue)
 
         return data
     }

--- a/OmniKit/OmnipodCommon/Pod.swift
+++ b/OmniKit/OmnipodCommon/Pod.swift
@@ -30,9 +30,6 @@ public struct Pod {
     // Units per second for priming/cannula insertion
     public static let primeDeliveryRate: Double = Pod.pulseSize / Pod.secondsPerPrimePulse
 
-    // User configured time before expiration advisory (PDM allows 1-24 hours)
-    public static let expirationAlertWindow = TimeInterval(hours: 2)
-
     // Expiration advisory window: time after expiration alert, and end of service imminent alarm
     public static let expirationAdvisoryWindow = TimeInterval(hours: 7)
 
@@ -111,7 +108,7 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     case bolusAndTempBasal = 6
     case extendedBolusRunning = 9
     case extendedBolusAndTempBasal = 10
-    
+
     public var suspended: Bool {
         return self == .suspended
     }
@@ -119,7 +116,7 @@ public enum DeliveryStatus: UInt8, CustomStringConvertible {
     public var bolusing: Bool {
         return self == .bolusInProgress || self == .bolusAndTempBasal || self == .extendedBolusRunning || self == .extendedBolusAndTempBasal
     }
-    
+
     public var tempBasalRunning: Bool {
         return self == .tempBasalRunning || self == .bolusAndTempBasal || self == .extendedBolusAndTempBasal
     }

--- a/OmniKit/OmnipodCommon/SilencePodPreference.swift
+++ b/OmniKit/OmnipodCommon/SilencePodPreference.swift
@@ -1,0 +1,32 @@
+//
+//  SilencePodPreference.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 8/30/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+public enum SilencePodPreference: Int, CaseIterable {
+    case disabled
+    case enabled
+
+    public var title: String {
+        switch self {
+        case .disabled:
+            return LocalizedString("Disabled", comment: "Title string for SilencePodPreference.disabled")
+        case .enabled:
+            return LocalizedString("Silenced", comment: "Title string for SilencePodPreference.enabled")
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .disabled:
+            return LocalizedString("Normal operation mode where audible Pod beeps are used for all Pod alerts and when confidence reminders are enabled.", comment: "Description for SilencePodPreference.disabled")
+        case .enabled:
+            return LocalizedString("All Pod alerts use no beeps and confirmation reminder beeps are suppressed. The Pod will only beep for fatal Pod faults and when playing test beeps.\n\n⚠️Warning - Whenever the Pod is silenced it must be kept within Bluetooth range of this device to receive notifications for Pod alerts.", comment: "Description for SilencePodPreference.enabled")
+        }
+    }
+}

--- a/OmniKit/PumpManager/DetailedStatus+OmniKit.swift
+++ b/OmniKit/PumpManager/DetailedStatus+OmniKit.swift
@@ -8,46 +8,34 @@
 
 import Foundation
 
-// Returns an appropropriate Eros PDM style Ref string for the Detailed Status. For most Eros faults generating
-// a standard style Ref code, TT-VVVHH-IIIRR-FFF is computed as {19|17}-{VV}{SSSS/60}-{NNNN/20}{RRRR/20}-PP.
+// Returns an appropropriate PDM style Ref string for the Detailed Status.
+// For most types, Ref: TT-VVVHH-IIIRR-FFF computed as {19|17}-{VV}{SSSS/60}-{NNNN/20}{RRRR/20}-PP
 extension DetailedStatus {
     public var pdmRef: String? {
-        let TT: UInt8 // 11 (0x31 fault), 17 (0x14 occlusion fault) or 19 (other faults)
-        let VVV: UInt8 // raw DetailedStatus VV byte (for non-occlusion faults)
-        let HH: UInt8 = UInt8(timeActive.hours) // # of pod hours
-        let III: UInt8 = UInt8(totalInsulinDelivered) // units of insulin
-        let RR: UInt8 = UInt8(self.reservoirLevel) // reservoir units, special 50+ U value becomes 51 as needed
-        let FFF: UInt8 // actual fault code value (for non-occlusion faults)
+        let TT, VVV, HH, III, RR, FFF: UInt8
 
         switch faultEventCode.faultType {
-
-        case .noFaults:
-            return nil  // not a pod fault
-
-        case .reservoirEmpty, .exceededMaximumPodLife80Hrs:
-            return nil  // no Eros PDM Ref code is displayed for either of these faults
-
-        // The Eros PDM does not display a Ref code an Auto Off 0 (the only # that the PDM uses) pod fault.
-        // While Loop doesn't use this feature, extend this to all Auto Off #'s in case they ever do get used.
-        case .autoOff0, .autoOff1, .autoOff2, .autoOff3, .autoOff4, .autoOff5, .autoOff6, .autoOff7:
-            return nil  // no Eros PDM Ref code displayed for Auto-off pod faults
-
-        // The Eros PDM treats the 0x31 (049) fault as a PDM error using a unique alternate TT=11 Ref code format.
+        case .noFaults, .reservoirEmpty, .exceededMaximumPodLife80Hrs:
+            return nil      // no PDM Ref # generated for these cases
         case .insulinDeliveryCommandError:
-            return "11-144-0018-00049" // all fixed values for an Eros 0x31 fault
-
-        // The Eros PDM uses VVV and FFF values of 000 in the Ref code for the 0x14 (020) occlusion fault.
+            // This fault is treated as a PDM fault which uses an alternate Ref format
+            return "11-144-0018-00049" // all fixed values for this fault
         case .occluded:
-            TT = 17     // Eros PDM Ref: 17-000HH-IIIRR-000
-            VVV = 0     // no VVV value given for an Eros occlusion fault
-            FFF = 0     // no FFF value given for an Eros occlusion fault
-
-        // The standard Ref code displayed for all other Eros pod faults
+            // Ref: 17-000HH-IIIRR-000
+            TT = 17         // Occlusion detected Ref type
+            VVV = 0         // no VVV value for an occlusion fault
+            FFF = 0         // no FFF value for an occlusion fault
         default:
-            TT = 19     // Eros PDM Ref: 19-VVVHH-IIIRR-FFF
-            VVV = data[17]
+            // Ref: 19-VVVHH-IIIRR-FFF
+            TT = 19         // pod fault Ref type
+            VVV = data[17]  // use the raw VV byte value
             FFF = faultEventCode.rawValue
         }
+
+        HH = UInt8(timeActive.hours)
+        III = UInt8(totalInsulinDelivered)
+
+        RR = UInt8(self.reservoirLevel) // special 51.15 value used for > 50U will become 51 as needed
 
         return String(format: "%02d-%03d%02d-%03d%02d-%03d", TT, VVV, HH, III, RR, FFF)
     }

--- a/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -59,6 +59,8 @@ extension OmnipodPumpManagerError: LocalizedError {
             return LocalizedString("Insulin type not configured", comment: "Error description for insulin type not configured")
         case .notReadyForCannulaInsertion:
             return LocalizedString("Pod is not in a state ready for cannula insertion.", comment: "Error message when cannula insertion fails because the pod is in an unexpected state")
+        case .invalidSetting:
+            return LocalizedString("Invalid Setting", comment: "Error description for invalid setting")
         case .communication(let error):
             if let error = error as? LocalizedError {
                 return error.errorDescription
@@ -71,8 +73,6 @@ extension OmnipodPumpManagerError: LocalizedError {
             } else {
                 return String(describing: error)
             }
-        case .invalidSetting:
-            return LocalizedString("Invalid Setting", comment: "Error description for invalid setting")
         }
     }
 
@@ -143,14 +143,6 @@ public class OmnipodPumpManager: RileyLinkPumpManager {
         return setStateWithResult(changes)
     }
 
-    @discardableResult
-    private func mutateState(_ changes: (_ state: inout OmnipodPumpManagerState) -> Void) -> OmnipodPumpManagerState {
-        return setStateWithResult({ (state) -> OmnipodPumpManagerState in
-            changes(&state)
-            return state
-        })
-    }
-
     private func setStateWithResult<ReturnType>(_ changes: (_ state: inout OmnipodPumpManagerState) -> ReturnType) -> ReturnType {
         var oldValue: OmnipodPumpManagerState!
         var returnType: ReturnType!
@@ -177,14 +169,6 @@ public class OmnipodPumpManager: RileyLinkPumpManager {
                         self.log.info("DU: updating reservoir level %{public}@", String(describing: reservoirLevel))
                         delegate?.pumpManager(self, didReadReservoirValue: reservoirLevel, at: lastInsulinMeasurements.validTime) { _ in }
                     })
-                }
-            }
-
-            if oldValue.podState?.setupProgress != newValue.podState?.setupProgress, newValue.podState?.setupProgress == .completed {
-                self.pumpDelegate.notify() { (delegate) in
-                    let date = Date()
-                    let event = NewPumpEvent(date: date, dose: nil, raw: "Pod Change \(date)".data(using: .utf8)!, title: "Pod Change", type: .replaceComponent(componentType: .pump))
-                    delegate?.pumpManager(self, hasNewPumpEvents: [event], lastReconciliation: self.lastSync, replacePendingEvents: false) { _ in }
                 }
             }
         }
@@ -290,12 +274,14 @@ public class OmnipodPumpManager: RileyLinkPumpManager {
     override public var debugDescription: String {
         let lines = [
             "## OmnipodPumpManager",
-            "podComms: \(String(reflecting: podComms))",
-            "state: \(String(reflecting: state))",
-            "status: \(String(describing: status))",
-            "podStateObservers.count: \(podStateObservers.cleanupDeallocatedElements().count)",
-            "statusObservers.count: \(statusObservers.cleanupDeallocatedElements().count)",
+            "",
             super.debugDescription,
+            "podComms: \(String(reflecting: podComms))",
+            "statusObservers.count: \(statusObservers.cleanupDeallocatedElements().count)",
+            "status: \(String(describing: status))",
+            "",
+            "podStateObservers.count: \(podStateObservers.cleanupDeallocatedElements().count)",
+            "state: \(String(reflecting: state))",
         ]
         return lines.joined(separator: "\n")
     }
@@ -556,10 +542,21 @@ extension OmnipodPumpManager {
         return false
     }
 
+    private var podTime: TimeInterval {
+        get {
+            guard let podState = state.podState else {
+                return 0
+            }
+            let elapsed = -(podState.podTimeUpdated?.timeIntervalSinceNow ?? 0)
+            let podActiveTime = podState.podTime + elapsed
+            return podActiveTime
+        }
+    }
+
     // Returns a suitable beep command MessageBlock based the current beep preferences and
     // whether there is an unfinializedDose for a manual temp basal &/or a manual bolus.
     private func beepMessageBlock(beepType: BeepType) -> MessageBlock? {
-        guard self.beepPreference.shouldBeepForManualCommand else {
+        guard self.beepPreference.shouldBeepForManualCommand && !self.silencePod else {
             return nil
         }
 
@@ -643,6 +640,13 @@ extension OmnipodPumpManager {
         }
     }
 
+    // Thread-safe
+    public var silencePod: Bool {
+        get {
+            return state.silencePod
+        }
+    }
+
     // From last status response
     public var reservoirLevel: ReservoirLevel? {
         return state.reservoirLevel
@@ -706,6 +710,7 @@ extension OmnipodPumpManager {
                     if error != nil {
                         state.unstoredDoses.append(contentsOf: dosesToStore)
                     }
+
                     resetPodState(&state)
                 })
                 completion()
@@ -835,7 +840,7 @@ extension OmnipodPumpManager {
                         state.pairingAttemptAddress = nil
                     }
                 }
-                
+
                 // Have new podState, reset all the per pod pump manager state
                 self.resetPerPodPumpManagerState()
 
@@ -922,15 +927,13 @@ extension OmnipodPumpManager {
                         }
                     }
 
-                    let expiration = self.podExpiresAt ?? Date().addingTimeInterval(Pod.nominalPodLife)
-                    let timeUntilExpirationReminder = expiration.addingTimeInterval(-self.state.defaultExpirationReminderOffset).timeIntervalSince(self.dateGenerator())
-
+                    let expirationReminderTime = Pod.nominalPodLife - self.state.defaultExpirationReminderOffset
                     let alerts: [PodAlert] = [
-                        .expirationReminder(self.state.defaultExpirationReminderOffset > 0 ? timeUntilExpirationReminder : 0),
-                        .lowReservoir(self.state.lowReservoirReminderValue)
+                        .expirationReminder(offset: self.podTime, absAlertTime: self.state.defaultExpirationReminderOffset > 0 ? expirationReminderTime : 0, silent: self.state.silencePod),
+                        .lowReservoir(units: self.state.lowReservoirReminderValue, silent: self.state.silencePod)
                     ]
 
-                    let finishWait = try session.insertCannula(optionalAlerts: alerts)
+                    let finishWait = try session.insertCannula(optionalAlerts: alerts, silent: self.state.silencePod)
                     completion(.success(finishWait))
                 } catch let error {
                     completion(.failure(.communication(error)))
@@ -1015,6 +1018,62 @@ extension OmnipodPumpManager {
         }
     }
 
+    public func getDetailedStatus(completion: ((_ result: PumpManagerResult<DetailedStatus>) -> Void)? = nil) {
+
+        // use hasSetupPod here instead of hasActivePod as DetailedStatus can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion?(.failure(PumpManagerError.configuration(OmnipodPumpManagerError.noPodPaired)))
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        podComms.runSession(withName: "Get detailed status", using: rileyLinkSelector) { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .bipBip)
+                    let detailedStatus = try session.getDetailedStatus(beepBlock: beepBlock)
+                    session.dosesForStorage({ (doses) -> Bool in
+                        self.store(doses: doses, in: session)
+                    })
+                    completion?(.success(detailedStatus))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion?(.failure(.communication(error as? LocalizedError)))
+                self.log.error("Failed to fetch detailed status: %{public}@", String(describing: error))
+            }
+        }
+    }
+
+    public func acknowledgePodAlerts(_ alertsToAcknowledge: AlertSet, completion: @escaping (_ alerts: AlertSet?) -> Void) {
+        guard self.hasActivePod else {
+            completion(nil)
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        self.podComms.runSession(withName: "Acknowledge Alerts", using: rileyLinkSelector) { (result) in
+            let session: PodCommsSession
+            switch result {
+            case .success(let s):
+                session = s
+            case .failure:
+                completion(nil)
+                return
+            }
+
+            do {
+                let beepBlock = self.beepMessageBlock(beepType: .bipBip)
+                let alerts = try session.acknowledgeAlerts(alerts: alertsToAcknowledge, beepBlock: beepBlock)
+                completion(alerts)
+            } catch {
+                completion(nil)
+            }
+        }
+    }
+
     public func setTime(completion: @escaping (OmnipodPumpManagerError?) -> Void) {
 
         let timeZone = TimeZone.currentFixed
@@ -1045,7 +1104,7 @@ extension OmnipodPumpManager {
             switch result {
             case .success(let session):
                 do {
-                    let beep = self.beepPreference.shouldBeepForManualCommand
+                    let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                     let _ = try session.setTime(timeZone: timeZone, basalSchedule: self.state.basalSchedule, date: Date(), acknowledgementBeep: beep)
                     self.setState { (state) in
                         state.timeZone = timeZone
@@ -1107,7 +1166,7 @@ extension OmnipodPumpManager {
                     case .success:
                         break
                     }
-                    let beep = self.beepPreference.shouldBeepForManualCommand
+                    let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                     let _ = try session.setBasalSchedule(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep)
 
                     self.setState { (state) in
@@ -1170,12 +1229,12 @@ extension OmnipodPumpManager {
         self.podComms.runSession(withName: "Play Test Beeps", using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
-                // preserve Pod completion beep state for any unfinalized manual insulin delivery
-                let beep = self.beepPreference.shouldBeepForManualCommand
+                // preserve the pod's completion beep state which gets reset playing beeps
+                let enabled: Bool = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
                 let result = session.beepConfig(
                     beepType: .bipBeepBipBeepBipBeepBipBeep,
-                    tempBasalCompletionBeep: beep && self.hasUnfinalizedManualTempBasal,
-                    bolusCompletionBeep: beep && self.hasUnfinalizedManualBolus
+                    tempBasalCompletionBeep: enabled && self.hasUnfinalizedManualTempBasal,
+                    bolusCompletionBeep: enabled && self.hasUnfinalizedManualBolus
                 )
 
                 switch result {
@@ -1191,7 +1250,7 @@ extension OmnipodPumpManager {
     }
 
     public func readPulseLog(completion: @escaping (Result<String, Error>) -> Void) {
-        // use hasSetupPod to be able to read the pulse log from a faulted Pod
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
         guard self.hasSetupPod else {
             completion(.failure(OmnipodPumpManagerError.noPodPaired))
             return
@@ -1228,18 +1287,106 @@ extension OmnipodPumpManager {
         }
     }
 
+    public func readPulseLogPlus(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmnipodPumpManagerError.noPodPaired))
+            return
+        }
+        guard state.podState?.isFaulted == true || state.podState?.unfinalizedBolus?.scheduledCertainty == .uncertain || state.podState?.unfinalizedBolus?.isFinished() != false else
+        {
+            self.log.info("Skipping Read Pulse Log Plus due to bolus still in progress.")
+            completion(.failure(PodCommsError.unfinalizedBolus))
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        podComms.runSession(withName: "Read Pulse Log Plus", using: rileyLinkSelector) { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .bipBeeeeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .pulseLogPlus, beepBlock: beepBlock)
+                    let podInfoPulseLogPlus = podInfoResponse.podInfo as! PodInfoPulseLogPlus
+                    let str = pulseLogPlusString(podInfoPulseLogPlus: podInfoPulseLogPlus)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func readActivationTime(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmnipodPumpManagerError.noPodPaired))
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        podComms.runSession(withName: "Read Activation Time", using: rileyLinkSelector) { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .beepBeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .activationTime, beepBlock: beepBlock)
+                    let podInfoActivationTime = podInfoResponse.podInfo as! PodInfoActivationTime
+                    let str = activationTimeString(podInfoActivationTime: podInfoActivationTime)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    public func readTriggeredAlerts(completion: @escaping (Result<String, Error>) -> Void) {
+        // use hasSetupPod here instead of hasActivePod as PodInfo can be read with a faulted Pod
+        guard self.hasSetupPod else {
+            completion(.failure(OmnipodPumpManagerError.noPodPaired))
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        podComms.runSession(withName: "Read Triggered Alerts", using: rileyLinkSelector) { (result) in
+            do {
+                switch result {
+                case .success(let session):
+                    let beepBlock = self.beepMessageBlock(beepType: .beepBeep)
+                    let podInfoResponse = try session.readPodInfo(podInfoResponseSubType: .triggeredAlerts, beepBlock: beepBlock)
+                    let podInfoTriggeredAlerts = podInfoResponse.podInfo as! PodInfoTriggeredAlerts
+                    let str = triggeredAlertsString(podInfoTriggeredAlerts: podInfoTriggeredAlerts)
+                    completion(.success(str))
+                case .failure(let error):
+                    throw error
+                }
+            } catch let error {
+                completion(.failure(error))
+            }
+        }
+    }
+
     public func setConfirmationBeeps(newPreference: BeepPreference, completion: @escaping (OmnipodPumpManagerError?) -> Void) {
-        self.log.default("Set Confirmation Beeps to %s", String(describing: newPreference))
-        guard self.hasActivePod else {
+
+        // If there isn't an active pod or the pod is currently silenced,
+        // just need to update the internal state without any pod commands.
+        let name = String(format: "Set Beep Preference to %@", String(describing: newPreference))
+        if !self.hasActivePod || self.silencePod {
+            self.log.default("%{public}@ for internal state only", name)
             self.setState { state in
-                state.confirmationBeeps = newPreference // set here to allow changes on a faulted Pod
+                state.confirmationBeeps = newPreference
             }
             completion(nil)
             return
         }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
-        self.podComms.runSession(withName: "Set Confirmation Beeps Preference", using: rileyLinkSelector) { (result) in
+        self.podComms.runSession(withName: name, using: rileyLinkSelector) { (result) in
             switch result {
             case .success(let session):
                 // enable/disable Pod completion beep state for any unfinalized manual insulin delivery
@@ -1261,6 +1408,76 @@ extension OmnipodPumpManager {
                     completion(.communication(error))
                 }
             case .failure(let error):
+                completion(.communication(error))
+            }
+        }
+    }
+
+    // Reconfigures all active alerts in pod to be silent or not as well as sets/clears the
+    // self.silencePod state variable which silences all confirmation beeping when enabled.
+    public func setSilencePod(silencePod: Bool, completion: @escaping (OmnipodPumpManagerError?) -> Void) {
+
+        let name = String(format: "%@ Pod", silencePod ? "Silence" : "Unsilence")
+        // allow Silence Pod changes without an active Pod
+        guard self.hasActivePod else {
+            self.log.default("%{public}@", name)
+            self.setState { state in
+                state.silencePod = silencePod
+            }
+            completion(nil)
+            return
+        }
+
+        let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
+        self.podComms.runSession(withName: name, using: rileyLinkSelector) { (result) in
+
+            let session: PodCommsSession
+            switch result {
+            case .success(let s):
+                session = s
+            case .failure(let error):
+                completion(.communication(error))
+                return
+            }
+
+            guard let configuredAlerts = self.state.podState?.configuredAlerts,
+                  let activeAlertSlots = self.state.podState?.activeAlertSlots,
+                  let reservoirLevel = self.state.podState?.lastInsulinMeasurements?.reservoirLevel?.rawValue else
+            {
+                self.log.error("Missing podState") // should never happen
+                completion(OmnipodPumpManagerError.noPodPaired)
+                return
+            }
+
+            let beepBlock: MessageBlock?
+            if !self.beepPreference.shouldBeepForManualCommand {
+                // No enabled completion beeps to worry about for any in-progress manual delivery
+                beepBlock = nil
+            } else if silencePod {
+                // Disable completion beeps for any in-progress manual delivery w/o beeping
+                beepBlock = BeepConfigCommand(beepType: .noBeepNonCancel)
+            } else {
+                // Emit a confirmation beep and enable completion beeps for any in-progress manual delivery
+                beepBlock = BeepConfigCommand(
+                    beepType: .bipBip,
+                    tempBasalCompletionBeep: self.hasUnfinalizedManualTempBasal,
+                    bolusCompletionBeep: self.hasUnfinalizedManualBolus
+                )
+            }
+
+            let podAlerts = regeneratePodAlerts(silent: silencePod, configuredAlerts: configuredAlerts, activeAlertSlots: activeAlertSlots, currentPodTime: self.podTime, currentReservoirLevel: reservoirLevel)
+            do {
+                // Since non-responsive pod comms are currently only resolved for insulin related commands,
+                // it's possible that a response from a previous successful pod alert configuration can be lost
+                // and thus the alert won't get reset here when reconfiguring pod alerts with a new silence pod state.
+                let acknowledgeAll = true   // protect against lost alert configuration response related issues
+                try session.configureAlerts(podAlerts, acknowledgeAll: acknowledgeAll, beepBlock: beepBlock)
+                self.setState { (state) in
+                    state.silencePod = silencePod
+                }
+                completion(nil)
+            } catch {
+                self.log.error("Configure alerts %{public}@ failed: %{public}@", String(describing: podAlerts), String(describing: error))
                 completion(.communication(error))
             }
         }
@@ -1357,7 +1574,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public var defaultExpirationReminderOffset: TimeInterval {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.defaultExpirationReminderOffset = newValue
             }
         }
@@ -1368,7 +1585,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public var lowReservoirReminderValue: Double {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.lowReservoirReminderValue = newValue
             }
         }
@@ -1379,7 +1596,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public var podAttachmentConfirmed: Bool {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.podAttachmentConfirmed = newValue
             }
         }
@@ -1390,7 +1607,7 @@ extension OmnipodPumpManager: PumpManager {
 
     public var initialConfigurationCompleted: Bool {
         set {
-            mutateState { (state) in
+            setState { (state) in
                 state.initialConfigurationCompleted = newValue
             }
         }
@@ -1475,7 +1692,7 @@ extension OmnipodPumpManager: PumpManager {
 
             // Use a beepBlock for the confirmation beep to avoid getting 3 beeps using cancel command beeps!
             let beepBlock = self.beepMessageBlock(beepType: .beeeeeep)
-            let result = session.suspendDelivery(suspendReminder: suspendReminder, beepBlock: beepBlock)
+            let result = session.suspendDelivery(suspendReminder: suspendReminder, silent: self.silencePod, beepBlock: beepBlock)
             switch result {
             case .certainFailure(let error):
                 self.log.error("Failed to suspend: %{public}@", String(describing: error))
@@ -1521,8 +1738,8 @@ extension OmnipodPumpManager: PumpManager {
 
             do {
                 let scheduleOffset = self.state.timeZone.scheduleOffset(forDate: Date())
-                let beep = self.beepPreference.shouldBeepForManualCommand
-                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep, completionBeep: beep)
+                let beep = self.silencePod ? false : self.beepPreference.shouldBeepForManualCommand
+                let _ = try session.resumeBasal(schedule: self.state.basalSchedule, scheduleOffset: scheduleOffset, acknowledgementBeep: beep)
                 self.clearSuspendReminder()
                 session.dosesForStorage() { (doses) -> Bool in
                     return self.store(doses: doses, in: session)
@@ -1598,8 +1815,14 @@ extension OmnipodPumpManager: PumpManager {
         // Round to nearest supported volume
         let enactUnits = roundToSupportedBolusVolume(units: units)
 
-        let acknowledgementBeep = self.beepPreference.shouldBeepForCommand(automatic: activationType.isAutomatic)
-        let completionBeep = beepPreference.shouldBeepForManualCommand && !activationType.isAutomatic
+        let acknowledgementBeep, completionBeep: Bool
+        if self.silencePod {
+            acknowledgementBeep = false
+            completionBeep = false
+        } else {
+            acknowledgementBeep = self.beepPreference.shouldBeepForCommand(automatic: activationType.isAutomatic)
+            completionBeep = beepPreference.shouldBeepForManualCommand && !activationType.isAutomatic
+        }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Bolus", using: rileyLinkSelector) { (result) in
@@ -1691,7 +1914,7 @@ extension OmnipodPumpManager: PumpManager {
                 }
 
                 // when cancelling a bolus use the built-in type 6 beeeeeep to match PDM if confirmation beeps are enabled
-                let beepType: BeepType = self.beepPreference.shouldBeepForManualCommand ? .beeeeeep : .noBeepCancel
+                let beepType: BeepType = self.beepPreference.shouldBeepForManualCommand && !self.silencePod ? .beeeeeep : .noBeepCancel
                 let result = session.cancelDelivery(deliveryType: .bolus, beepType: beepType)
                 switch result {
                 case .certainFailure(let error):
@@ -1729,7 +1952,7 @@ extension OmnipodPumpManager: PumpManager {
             completion(.deviceState(PodCommsError.setupNotComplete))
             return
         }
-  
+
         // Legal duration values are [virtual] zero (to cancel current temp basal) or between 30 min and 12 hours
         guard duration < .ulpOfOne || (duration >= .minutes(30) && duration <= .hours(12)) else {
             completion(.deviceState(OmnipodPumpManagerError.invalidSetting))
@@ -1739,8 +1962,14 @@ extension OmnipodPumpManager: PumpManager {
         // Round to nearest supported rate
         let rate = roundToSupportedBasalRate(unitsPerHour: unitsPerHour)
 
-        let acknowledgementBeep = beepPreference.shouldBeepForCommand(automatic: automatic)
-        let completionBeep = beepPreference.shouldBeepForManualCommand && !automatic
+        let acknowledgementBeep, completionBeep: Bool
+        if self.silencePod {
+            acknowledgementBeep = false
+            completionBeep = false
+        } else {
+            acknowledgementBeep = beepPreference.shouldBeepForCommand(automatic: automatic)
+            completionBeep = beepPreference.shouldBeepForManualCommand && !automatic
+        }
 
         let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
         self.podComms.runSession(withName: "Enact Temp Basal", using: rileyLinkSelector) { (result) in
@@ -1871,7 +2100,7 @@ extension OmnipodPumpManager: PumpManager {
     }
 
     public func syncDeliveryLimits(limits deliveryLimits: DeliveryLimits, completion: @escaping (Result<DeliveryLimits, Error>) -> Void) {
-        mutateState { state in
+        setState { state in
             if let rate = deliveryLimits.maximumBasalRate?.doubleValue(for: .internationalUnitsPerHour) {
                 state.maximumTempBasalRate = rate
                 completion(.success(deliveryLimits))
@@ -1917,16 +2146,25 @@ extension OmnipodPumpManager: PumpManager {
                 return
             }
 
-            var timeUntilReminder : TimeInterval = 0
+            let podTime = self.podTime
+            var expirationReminderPodTime: TimeInterval = 0 // default to expiration reminder alert inactive
+
+            // If the interval before expiration is not a positive value (e.g., it's in the past),
+            // then the pod alert will get the default alert time of 0 making this alert inactive.
             if let intervalBeforeExpiration = intervalBeforeExpiration, intervalBeforeExpiration > 0 {
-                timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+                let timeUntilReminder = expiresAt.addingTimeInterval(-intervalBeforeExpiration).timeIntervalSince(self.dateGenerator())
+                // Only bother to set an expiration reminder pod alert if it is still at least a couple of minutes in the future
+                if timeUntilReminder > .minutes(2) {
+                    expirationReminderPodTime = podTime + timeUntilReminder
+                    self.log.debug("Update Expiration timeUntilReminder=%@, podTime=%@, expirationReminderPodTime=%@", timeUntilReminder.timeIntervalStr, podTime.timeIntervalStr, expirationReminderPodTime.timeIntervalStr)
+                }
             }
 
-            let expirationReminder = PodAlert.expirationReminder(timeUntilReminder)
+            let expirationReminder = PodAlert.expirationReminder(offset: podTime, absAlertTime: expirationReminderPodTime, silent: self.silencePod)
             do {
                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                 try session.configureAlerts([expirationReminder], beepBlock: beepBlock)
-                self.mutateState({ (state) in
+                self.setState({ (state) in
                     state.scheduledExpirationReminderOffset = intervalBeforeExpiration
                 })
                 completion(nil)
@@ -1950,7 +2188,8 @@ extension OmnipodPumpManager: PumpManager {
             expiration.addingTimeInterval(.hours(Double(i)))
         }
         let now = dateGenerator()
-        return allDates.filter { $0.timeIntervalSince(now) > 0 }
+        // Have a couple minutes of slop to avoid confusion trying to set an expiration reminder too close to now
+        return allDates.filter { $0.timeIntervalSince(now) > .minutes(2) }
     }
 
     public var scheduledExpirationReminder: Date? {
@@ -1963,9 +2202,26 @@ extension OmnipodPumpManager: PumpManager {
         return expiration.addingTimeInterval(-.hours(round(offset.hours)))
     }
 
+    // Updates the low reservior reminder value both for the current pod (when applicable) and for future pods
     public func updateLowReservoirReminder(_ value: Int, completion: @escaping (OmnipodPumpManagerError?) -> Void) {
+
+        let supportedValue = min(max(0, Double(value)), Pod.maximumReservoirReading)
+        let setLowReservoirReminderValue = {
+            self.log.default("Set Low Reservoir Reminder to %d U", value)
+            self.lowReservoirReminderValue = supportedValue
+            completion(nil)
+        }
+
         guard self.hasActivePod else {
-            completion(OmnipodPumpManagerError.noPodPaired)
+            // no active pod, just set the internal state for the next pod
+            setLowReservoirReminderValue()
+            return
+        }
+
+        guard let currentReservoirLevel = self.reservoirLevel?.rawValue, currentReservoirLevel > supportedValue else {
+            // Since the new low reservoir alert level is not below the current reservoir value,
+            // just set the internal state for the next pod to prevent an immediate low reservoir alert.
+            setLowReservoirReminderValue()
             return
         }
 
@@ -1981,13 +2237,11 @@ extension OmnipodPumpManager: PumpManager {
                 return
             }
 
-            let lowReservoirReminder = PodAlert.lowReservoir(Double(value))
+            let lowReservoirReminder = PodAlert.lowReservoir(units: supportedValue, silent: self.silencePod)
             do {
                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                 try session.configureAlerts([lowReservoirReminder], beepBlock: beepBlock)
-                self.mutateState({ (state) in
-                    state.lowReservoirReminderValue = Double(value)
-                })
+                self.lowReservoirReminderValue = supportedValue
                 completion(nil)
             } catch {
                 completion(.communication(error))
@@ -2012,7 +2266,7 @@ extension OmnipodPumpManager: PumpManager {
             }
         }
 
-        self.mutateState { (state) in
+        self.setState { (state) in
             state.activeAlerts.insert(alert)
         }
     }
@@ -2028,7 +2282,7 @@ extension OmnipodPumpManager: PumpManager {
                 delegate?.retractAlert(identifier: repeatingIdentifier)
             }
         }
-        self.mutateState { (state) in
+        self.setState { (state) in
             state.activeAlerts.remove(alert)
         }
     }
@@ -2049,6 +2303,8 @@ extension OmnipodPumpManager: PumpManager {
                 }
             } else {
                 log.error("Unconfigured alert slot triggered: %{public}@", String(describing: slot))
+                let pumpManagerAlert = PumpManagerAlert.unexpectedAlert(triggeringSlot: slot)
+                issueAlert(alert: pumpManagerAlert)
             }
         }
         for alert in removed {
@@ -2057,34 +2313,24 @@ extension OmnipodPumpManager: PumpManager {
     }
 
     private func getPumpManagerAlert(for podAlert: PodAlert, slot: AlertSlot) -> PumpManagerAlert? {
-        guard let podState = state.podState, let expiresAt = podState.expiresAt else {
-            preconditionFailure("trying to lookup alert info without podState")
-        }
-
-        guard !podAlert.isIgnored else {
-            return nil
-        }
 
         switch podAlert {
-        case .podSuspendedReminder:
-            return PumpManagerAlert.suspendInProgress(triggeringSlot: slot)
+        case .shutdownImminent:
+            return PumpManagerAlert.podExpireImminent(triggeringSlot: slot)
         case .expirationReminder:
-            guard let offset = state.scheduledExpirationReminderOffset, offset > 0 else {
-                return nil
+            guard let podState = state.podState, let expiresAt = podState.expiresAt else {
+                preconditionFailure("trying to lookup expiresAt")
             }
             let timeToExpiry = TimeInterval(hours: expiresAt.timeIntervalSince(dateGenerator()).hours.rounded())
             return PumpManagerAlert.userPodExpiration(triggeringSlot: slot, scheduledExpirationReminderOffset: timeToExpiry)
-        case .expired:
-            return PumpManagerAlert.podExpiring(triggeringSlot: slot)
-        case .shutdownImminent:
-            return PumpManagerAlert.podExpireImminent(triggeringSlot: slot)
-        case .lowReservoir(let units):
+        case .lowReservoir(let units, _):
             return PumpManagerAlert.lowReservoir(triggeringSlot: slot, lowReservoirReminderValue: units)
-        case .finishSetupReminder, .waitingForPairingReminder:
-            return PumpManagerAlert.finishSetupReminder(triggeringSlot: slot)
         case .suspendTimeExpired:
             return PumpManagerAlert.suspendEnded(triggeringSlot: slot)
+        case .expired:
+            return PumpManagerAlert.podExpiring(triggeringSlot: slot)
         default:
+            // No PumpManagerAlerts are used for any other pod alerts (including suspendInProgress).
             return nil
         }
     }
@@ -2102,7 +2348,7 @@ extension OmnipodPumpManager: PumpManager {
                         } catch {
                             return
                         }
-                        self.mutateState { state in
+                        self.setState { state in
                             state.activeAlerts.remove(alert)
                             state.alertsWithPendingAcknowledgment.remove(alert)
                         }
@@ -2226,7 +2472,7 @@ extension OmnipodPumpManager: PodCommsDelegate {
             }
         } else {
             // Resetting podState
-            mutateState { state in
+            setState { state in
                 state.updatePodStateFromPodComms(podState)
             }
         }
@@ -2242,9 +2488,16 @@ extension OmnipodPumpManager {
         }
 
         for alert in state.activeAlerts {
-            if alert.alertIdentifier == alertIdentifier {
+            if alert.alertIdentifier == alertIdentifier || alert.repeatingAlertIdentifier == alertIdentifier {
                 // If this alert was triggered by the pod find the slot to clear it.
                 if let slot = alert.triggeringSlot {
+                    if case .some(.suspended) = self.state.podState?.suspendState, slot == .slot6SuspendTimeExpired {
+                        // Don't clear this pod alert here with the pod still suspended so that the suspend time expired
+                        // pod alert beeping will continue until the pod is resumed which will then deactivate this alert.
+                        log.default("Skipping acknowledgement of suspend time expired alert with a suspended pod")
+                        completion(nil)
+                        return
+                    }
                     let rileyLinkSelector = self.rileyLinkDeviceProvider.firstConnectedDevice
                     self.podComms.runSession(withName: "Acknowledge Alert", using: rileyLinkSelector) { (result) in
                         switch result {
@@ -2253,18 +2506,18 @@ extension OmnipodPumpManager {
                                 let beepBlock = self.beepMessageBlock(beepType: .beep)
                                 let _ = try session.acknowledgeAlerts(alerts: AlertSet(slots: [slot]), beepBlock: beepBlock)
                             } catch {
-                                self.mutateState { state in
+                                self.setState { state in
                                     state.alertsWithPendingAcknowledgment.insert(alert)
                                 }
                                 completion(error)
                                 return
                             }
-                            self.mutateState { state in
+                            self.setState { state in
                                 state.activeAlerts.remove(alert)
                             }
                             completion(nil)
                         case .failure(let error):
-                            self.mutateState { state in
+                            self.setState { state in
                                 state.alertsWithPendingAcknowledgment.insert(alert)
                             }
                             completion(error)
@@ -2273,7 +2526,7 @@ extension OmnipodPumpManager {
                     }
                 } else {
                     // Non-pod alert
-                    self.mutateState { state in
+                    self.setState { state in
                         state.activeAlerts.remove(alert)
                         if alert == .timeOffsetChangeDetected {
                             state.acknowledgedTimeOffsetAlert = true
@@ -2302,7 +2555,7 @@ extension FaultEventCode {
         case .exceededMaximumPodLife80Hrs:
             return LocalizedString("Pod Expired", comment: "The title for Pod Expired alarm notification")
         default:
-            return LocalizedString("Critical Pod Error", comment: "The title for AlarmCode.other notification")
+            return String(format: LocalizedString("Critical Pod Fault %1$03d", comment: "The title for AlarmCode.other notification: (1: fault code value)"), self.rawValue)
         }
     }
 

--- a/OmniKit/PumpManager/OmnipodPumpManagerState.swift
+++ b/OmniKit/PumpManager/OmnipodPumpManagerState.swift
@@ -35,6 +35,8 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
 
     public var unstoredDoses: [UnfinalizedDose]
 
+    public var silencePod: Bool
+
     public var confirmationBeeps: BeepPreference
 
     public var scheduledExpirationReminderOffset: TimeInterval?
@@ -100,6 +102,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
         self.basalSchedule = basalSchedule
         self.rileyLinkConnectionManagerState = rileyLinkConnectionManagerState
         self.unstoredDoses = []
+        self.silencePod = false
         self.confirmationBeeps = .manualCommands
         self.insulinType = insulinType
         self.lowReservoirReminderValue = Pod.defaultLowReservoirReminder
@@ -186,6 +189,8 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             self.unstoredDoses = []
         }
 
+        self.silencePod = rawValue["silencePod"] as? Bool ?? false
+
         if let oldAutomaticBolusBeeps = rawValue["automaticBolusBeeps"] as? Bool, oldAutomaticBolusBeeps {
             self.confirmationBeeps = .extended
         } else if let oldConfirmationBeeps = rawValue["confirmationBeeps"] as? Bool, oldConfirmationBeeps {
@@ -253,6 +258,7 @@ public struct OmnipodPumpManagerState: RawRepresentable, Equatable {
             "timeZone": timeZone.secondsFromGMT(),
             "basalSchedule": basalSchedule.rawValue,
             "unstoredDoses": unstoredDoses.map { $0.rawValue },
+            "silencePod": silencePod,
             "confirmationBeeps": confirmationBeeps.rawValue,
             "activeAlerts": activeAlerts.map { $0.rawValue },
             "podAttachmentConfirmed": podAttachmentConfirmed,
@@ -303,8 +309,8 @@ extension OmnipodPumpManagerState: CustomDebugStringConvertible {
             "* timeZone: \(timeZone)",
             "* basalSchedule: \(String(describing: basalSchedule))",
             "* maximumTempBasalRate: \(maximumTempBasalRate)",
-            "* scheduledExpirationReminderOffset: \(String(describing: scheduledExpirationReminderOffset))",
-            "* defaultExpirationReminderOffset: \(String(describing: defaultExpirationReminderOffset))",
+            "* scheduledExpirationReminderOffset: \(String(describing: scheduledExpirationReminderOffset?.timeIntervalStr))",
+            "* defaultExpirationReminderOffset: \(defaultExpirationReminderOffset.timeIntervalStr)",
             "* lowReservoirReminderValue: \(String(describing: lowReservoirReminderValue))",
             "* podAttachmentConfirmed: \(podAttachmentConfirmed)",
             "* activeAlerts: \(activeAlerts)",
@@ -317,14 +323,21 @@ extension OmnipodPumpManagerState: CustomDebugStringConvertible {
             "* tempBasalEngageState: \(String(describing: tempBasalEngageState))",
             "* lastPumpDataReportDate: \(String(describing: lastPumpDataReportDate))",
             "* isPumpDataStale: \(String(describing: isPumpDataStale))",
+            "* silencePod: \(String(describing: silencePod))",
             "* confirmationBeeps: \(String(describing: confirmationBeeps))",
             "* pairingAttemptAddress: \(String(describing: pairingAttemptAddress))",
             "* insulinType: \(String(describing: insulinType))",
+            "* scheduledExpirationReminderOffset: \(String(describing: scheduledExpirationReminderOffset?.timeIntervalStr))",
+            "* defaultExpirationReminderOffset: \(defaultExpirationReminderOffset.timeIntervalStr)",
             "* rileyLinkBatteryAlertLevel: \(String(describing: rileyLinkBatteryAlertLevel))",
             "* lastRileyLinkBatteryAlertDate \(String(describing: lastRileyLinkBatteryAlertDate))",
-            String(reflecting: podState),
-            "* PreviousPodState: \(String(reflecting: previousPodState))",
-            String(reflecting: rileyLinkConnectionManagerState),
+            "",
+            "* RileyLinkConnectionManagerState: " + (rileyLinkConnectionManagerState == nil ? "nil" : String(describing: rileyLinkConnectionManagerState!)),
+            "",
+            "* PodState: " + (podState == nil ? "nil" : String(describing: podState!)),
+            "",
+            "* PreviousPodState: " + (previousPodState == nil ? "nil" : String(describing: previousPodState!)),
+            "",
         ].joined(separator: "\n")
     }
 }

--- a/OmniKit/PumpManager/PodComms.swift
+++ b/OmniKit/PumpManager/PodComms.swift
@@ -454,7 +454,6 @@ class PodComms: CustomDebugStringConvertible {
     var debugDescription: String {
         return [
             "## PodComms",
-            "podState: \(String(reflecting: podState))",
             "configuredDevices: \(configuredDevices.value.map { $0.uuidString })",
             "delegate: \(String(describing: delegate != nil))",
             ""

--- a/OmniKitTests/AcknowledgeAlertsTests.swift
+++ b/OmniKitTests/AcknowledgeAlertsTests.swift
@@ -22,7 +22,7 @@ class AcknowledgeAlertsTests: XCTestCase {
             let cmd = try AcknowledgeAlertCommand(encodedData: Data(hexadecimalString: "11052f9b5b2f10")!)
             XCTAssertEqual(.acknowledgeAlert,cmd.blockType)
             XCTAssertEqual(0x2f9b5b2f, cmd.nonce)
-            XCTAssert(cmd.alerts.contains(.slot4))
+            XCTAssert(cmd.alerts.contains(.slot4LowReservoir))
         } catch (let error) {
             XCTFail("message decoding threw error: \(error)")
         }

--- a/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
+++ b/OmniKitUI/ViewControllers/OmnipodUICoordinator.swift
@@ -197,7 +197,7 @@ class OmnipodUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
                 }
             }
 
-            let view = OmnipodSettingsView(viewModel: viewModel, rileyLinkListDataSource: rileyLinkListDataSource, handleRileyLinkSelection: handleRileyLinkSelection, supportedInsulinTypes: allowedInsulinTypes)
+            let view = OmnipodSettingsView(viewModel: viewModel, rileyLinkListDataSource: rileyLinkListDataSource, handleRileyLinkSelection: handleRileyLinkSelection, supportedInsulinTypes: allowedInsulinTypes, allowDebugFeatures: allowDebugFeatures)
             return hostingController(rootView: view)
         case .pairAndPrime:
             pumpManagerOnboardingDelegate?.pumpManagerOnboarding(didCreatePumpManager: pumpManager)

--- a/OmniKitUI/Views/ActivityView.swift
+++ b/OmniKitUI/Views/ActivityView.swift
@@ -1,0 +1,36 @@
+//
+//  ActivityView.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 9/17/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+struct ActivityView: UIViewControllerRepresentable {
+    @Binding var isPresented: Bool
+    let activityItems: [Any]
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<ActivityView>) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+        controller.completionWithItemsHandler = { (_, _, _, _) in
+            self.isPresented = false
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ActivityView>) {
+    }
+}
+
+fileprivate struct ActivityViewController: UIViewControllerRepresentable {
+    var activityItems: [Any]
+    var applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<ActivityViewController>) -> UIActivityViewController {
+        return UIActivityViewController(activityItems: activityItems, applicationActivities: applicationActivities)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: UIViewControllerRepresentableContext<ActivityViewController>) {}
+}

--- a/OmniKitUI/Views/FirstAppear.swift
+++ b/OmniKitUI/Views/FirstAppear.swift
@@ -1,0 +1,30 @@
+//
+//  FirstAppear.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 9/24/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+
+extension View {
+    func onFirstAppear(_ action: @escaping () -> ()) -> some View {
+        modifier(FirstAppear(action: action))
+    }
+}
+
+private struct FirstAppear: ViewModifier {
+    let action: () -> ()
+
+    // State used to insure action is invoked here only once
+    @State private var hasAppeared = false
+
+    func body(content: Content) -> some View {
+        content.onAppear {
+            guard !hasAppeared else { return }
+            hasAppeared = true
+            action()
+        }
+    }
+}

--- a/OmniKitUI/Views/OmnipodSettingsView.swift
+++ b/OmniKitUI/Views/OmnipodSettingsView.swift
@@ -14,31 +14,32 @@ import OmniKit
 import RileyLinkBLEKit
 
 struct OmnipodSettingsView: View  {
-    
+
     @ObservedObject var viewModel: OmnipodSettingsViewModel
 
     @ObservedObject var rileyLinkListDataSource: RileyLinkListDataSource
 
     var handleRileyLinkSelection: (RileyLinkDevice) -> Void
-    
+
     @State private var showingDeleteConfirmation = false
-    
-    @State private var showSuspendOptions = false;
 
-    @State private var showManualTempBasalOptions = false;
+    @State private var showSuspendOptions = false
 
-    @State private var showSyncTimeOptions = false;
+    @State private var showManualTempBasalOptions = false
 
-    @State private var sendingTestBeepsCommand = false;
+    @State private var showSyncTimeOptions = false
+
+    @State private var sendingTestBeepsCommand = false
 
     @State private var cancelingTempBasal = false
 
     var supportedInsulinTypes: [InsulinType]
 
-
     @Environment(\.guidanceColors) var guidanceColors
     @Environment(\.insulinTintColor) var insulinTintColor
     
+    let allowDebugFeatures : Bool
+
     private var daysRemaining: Int? {
         if case .timeRemaining(let remaining, _) = viewModel.lifeState, remaining > .days(1) {
             return Int(remaining.days)
@@ -286,7 +287,7 @@ struct OmnipodSettingsView: View  {
                     headerImage
 
                     lifecycleProgress
-                    
+
                     HStack(alignment: .top) {
                         deliveryStatus
                         Spacer()
@@ -309,7 +310,7 @@ struct OmnipodSettingsView: View  {
                     }.padding(.vertical, 8)
                 }
             }
-            
+
             Section(header: SectionHeader(label: LocalizedString("Activity", comment: "Section header for activity section"))) {
                 suspendResumeRow()
                     .disabled(!self.viewModel.podOk)
@@ -350,7 +351,7 @@ struct OmnipodSettingsView: View  {
                     manualTempBasalRow
                 }
             }
-            .disabled(cancelingTempBasal)
+            .disabled(cancelingTempBasal || !self.viewModel.podOk)
 
             Section(header: HStack {
                 FrameworkLocalText("Devices", comment: "Header for devices section of RileyLinkSetupView")
@@ -390,7 +391,7 @@ struct OmnipodSettingsView: View  {
                     Text(self.viewModel.activatedAtString)
                         .foregroundColor(Color.secondary)
                 }
-                
+
                 HStack {
                     if let expiresAt = viewModel.expiresAt, expiresAt < Date() {
                         FrameworkLocalText("Pod Expired", comment: "Label for pod expiration row, past tense")
@@ -401,21 +402,36 @@ struct OmnipodSettingsView: View  {
                     Text(self.viewModel.expiresAtString)
                         .foregroundColor(Color.secondary)
                 }
-                
+
                 if let podDetails = self.viewModel.podDetails {
-                    NavigationLink(destination: PodDetailsView(podDetails: podDetails, title: LocalizedString("Device Details", comment: "title for device details page"))) {
-                        FrameworkLocalText("Device Details", comment: "Text for device details disclosure row").foregroundColor(Color.primary)
+                    NavigationLink(destination: PodDetailsView(podDetails: podDetails, title: LocalizedString("Pod Details", comment: "title for pod details page"))) {
+                        FrameworkLocalText("Pod Details", comment: "Text for pod details disclosure row")
+                            .foregroundColor(Color.primary)
                     }
                 } else {
                     HStack {
-                        FrameworkLocalText("Device Details", comment: "Text for device details disclosure row")
+                        FrameworkLocalText("Pod Details", comment: "Text for pod details disclosure row")
+                        Spacer()
+                        Text("—")
+                            .foregroundColor(Color.secondary)
+                    }
+                }
+
+                if let previousPodDetails = viewModel.previousPodDetails {
+                    NavigationLink(destination: PodDetailsView(podDetails: previousPodDetails, title: LocalizedString("Previous Pod", comment: "title for previous pod page"))) {
+                        FrameworkLocalText("Previous Pod Details", comment: "Text for previous pod details row")
+                            .foregroundColor(Color.primary)
+                    }
+                } else {
+                    HStack {
+                        FrameworkLocalText("Previous Pod Details", comment: "Text for previous pod details row")
                         Spacer()
                         Text("—")
                             .foregroundColor(Color.secondary)
                     }
                 }
             }
-            
+
             Section() {
                 Button(action: {
                     self.viewModel.navigateTo?(self.viewModel.lifeState.nextPodLifecycleAction)
@@ -424,7 +440,7 @@ struct OmnipodSettingsView: View  {
                         .foregroundColor(self.viewModel.lifeState.nextPodLifecycleActionColor)
                 }
             }
-            
+
             Section(header: SectionHeader(label: LocalizedString("Configuration", comment: "Section header for configuration section")))
             {
                 NavigationLink(destination:
@@ -441,15 +457,27 @@ struct OmnipodSettingsView: View  {
                 }
                 NavigationLink(destination: BeepPreferenceSelectionView(initialValue: viewModel.beepPreference, onSave: viewModel.setConfirmationBeeps)) {
                     HStack {
-                        FrameworkLocalText("Confidence Reminders", comment: "Text for confidence reminders navigation link").foregroundColor(Color.primary)
+                        FrameworkLocalText("Confidence Reminders", comment: "Text for confidence reminders navigation link")
+                            .foregroundColor(Color.primary)
                         Spacer()
                         Text(viewModel.beepPreference.title)
                             .foregroundColor(.secondary)
                     }
                 }
+                if  (allowDebugFeatures) {
+                    NavigationLink(destination: SilencePodSelectionView(initialValue: viewModel.silencePodPreference, onSave: viewModel.setSilencePod)) {
+                        HStack {
+                            FrameworkLocalText("Silence Pod", comment: "Text for silence pod navigation link")
+                                .foregroundColor(Color.primary)
+                            Spacer()
+                            Text(viewModel.silencePodPreference.title)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
                 NavigationLink(destination: InsulinTypeSetting(initialValue: viewModel.insulinType, supportedInsulinTypes: supportedInsulinTypes, allowUnsetInsulinType: false, didChange: viewModel.didChangeInsulinType)) {
                     HStack {
-                        FrameworkLocalText("Insulin Type", comment: "Text for confidence reminders navigation link").foregroundColor(Color.primary)
+                        FrameworkLocalText("Insulin Type", comment: "Text for insulin type navigation link").foregroundColor(Color.primary)
                         if let currentTitle = viewModel.insulinType?.brandName {
                             Spacer()
                             Text(currentTitle)
@@ -458,7 +486,7 @@ struct OmnipodSettingsView: View  {
                     }
                 }
             }
-            
+
             Section() {
                 HStack {
                     FrameworkLocalText("Pump Time", comment: "The title of the command to change pump time zone")
@@ -489,14 +517,17 @@ struct OmnipodSettingsView: View  {
                 }
             }
 
-            if let previousPodDetails = viewModel.previousPodDetails {
+            if  (allowDebugFeatures) {
                 Section() {
-                    NavigationLink(destination: PodDetailsView(podDetails: previousPodDetails, title: LocalizedString("Previous Pod", comment: "title for previous pod page"))) {
-                        FrameworkLocalText("Previous Pod Information", comment: "Text for previous pod information row").foregroundColor(Color.primary)
+                    NavigationLink(destination: PodDiagnosticsView(
+                        title: LocalizedString("Pod Diagnostics", comment: "Title for the pod diagnostic view"),
+                        viewModel: viewModel))
+                    {
+                        FrameworkLocalText("Pod Diagnostics", comment: "Text for pod diagnostics row")
+                            .foregroundColor(Color.primary)
                     }
                 }
             }
-            
 
             if self.viewModel.lifeState.allowsPumpManagerRemoval {
                 Section() {
@@ -539,7 +570,7 @@ struct OmnipodSettingsView: View  {
     var suspendOptionsActionSheet: ActionSheet {
         ActionSheet(
             title: FrameworkLocalText("Suspend Delivery", comment: "Title for suspend duration selection action sheet"),
-            message: FrameworkLocalText("Insulin delivery will be stopped until you resume manually. When would you like Loop to remind you to resume delivery?", comment: "Message for suspend duration selection action sheet"),
+            message: FrameworkLocalText("Insulin delivery will be stopped until you resume manually. When would you like this app to remind you to resume delivery?", comment: "Message for suspend duration selection action sheet"),
             buttons: [
                 .default(FrameworkLocalText("30 minutes", comment: "Button text for 30 minute suspend duration"), action: { self.viewModel.suspendDelivery(duration: .minutes(30)) }),
                 .default(FrameworkLocalText("1 hour", comment: "Button text for 1 hour suspend duration"), action: { self.viewModel.suspendDelivery(duration: .hours(1)) }),

--- a/OmniKitUI/Views/PlayTestBeepsView.swift
+++ b/OmniKitUI/Views/PlayTestBeepsView.swift
@@ -1,0 +1,100 @@
+//
+//  PlayTestBeepsView.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 9/1/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct PlayTestBeepsView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: Error?) -> Void) -> Void)?
+
+    private let title = LocalizedString("Play Test Beeps", comment: "navigation title for play test beeps")
+    private let actionString = LocalizedString("Playing Test Beeps...", comment: "button title when executing play test beeps")
+    private let failedString: String = LocalizedString("Failed to play test beeps.", comment: "Alert title for error when playing test beeps")
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var successMessage = LocalizedString("Play test beeps command sent successfully.\n\nIf you did not hear any beeps from your Pod, the piezo speaker in your Pod may be broken or disabled.", comment: "Success message for play test beeps")
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    Text(self.displayString).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (error) in
+                executing = false
+                if let error = error {
+                    self.displayString = ""
+                    self.error = error
+                    self.alertIsPresented = true
+                } else {
+                    self.displayString = successMessage
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+struct PlayTestBeepsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            PlayTestBeepsView() { completion in
+                completion(nil)
+            }
+        }
+    }
+}

--- a/OmniKitUI/Views/PodDetailsView.swift
+++ b/OmniKitUI/Views/PodDetailsView.swift
@@ -89,7 +89,7 @@ struct PodDetailsView: View {
     var body: some View {
         List {
             row(LocalizedString("Lot Number", comment: "description label for lot number pod details row"), value: String(describing: podDetails.lotNumber))
-            row(LocalizedString("Sequence Number", comment: "description label for sequence number pod details row"), value: String(describing: podDetails.sequenceNumber))
+            row(LocalizedString("Sequence Number", comment: "description label for sequence number pod details row"), value: String(format: "%07d", podDetails.sequenceNumber))
             row(LocalizedString("PI Version", comment: "description label for pi version pod details row"), value: podDetails.piVersion)
             row(LocalizedString("PM Version", comment: "description label for ble firmware version pod details row"), value: podDetails.pmVersion)
             row(LocalizedString("Total Delivery", comment: "description label for total delivery pod details row"), value: totalDeliveryText)
@@ -108,10 +108,7 @@ struct PodDetailsView: View {
                             Text(LocalizedString("Pod Fault Details", comment: "description label for pod fault details"))
                                 .fontWeight(.semibold)
                         }.padding(.vertical, 4)
-                        Text(String(describing: fault))
-                            .fixedSize(horizontal: false, vertical: true)
-                            .foregroundColor(.secondary)
-                        Text("Ref: " + pdmRef)
+                        Text(String(format: LocalizedString("Internal Pod fault code %1$03d\n%2$@\nRef: %3$@\n", comment: "The format string for the pod fault info: (1: fault code) (2: fault description) (3: pdm ref string)"), fault.rawValue, fault.faultDescription, pdmRef))
                             .fixedSize(horizontal: false, vertical: true)
                             .foregroundColor(.secondary)
                     }
@@ -124,6 +121,6 @@ struct PodDetailsView: View {
 
 struct PodDetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        PodDetailsView(podDetails: PodDetails(lotNumber: 0x1234, sequenceNumber: 0x1234, piVersion: "1.1.1", pmVersion: "2.2.2", totalDelivery: 10, lastStatus: Date(), fault: FaultEventCode(rawValue: 0x67), activatedAt: Date().addingTimeInterval(.days(1))), title: "Device Details")
+        PodDetailsView(podDetails: PodDetails(lotNumber: 123456789, sequenceNumber: 1234567, piVersion: "2.1.0", pmVersion: "2.1.0", totalDelivery: 99, lastStatus: Date(), fault: FaultEventCode(rawValue: 064), activatedAt: Date().addingTimeInterval(.days(2)), pdmRef: "19-02448-09951-064"), title: "Device Details")
     }
 }

--- a/OmniKitUI/Views/PodDiagnostics.swift
+++ b/OmniKitUI/Views/PodDiagnostics.swift
@@ -1,0 +1,90 @@
+//
+//  PodDiagnotics.swift
+//  OmniKit
+//
+//  Created by Joseph Moran on 11/25/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import LoopKitUI
+import HealthKit
+import OmniKit
+
+
+struct PodDiagnosticsView: View  {
+
+    var title: String
+    
+    @ObservedObject var viewModel: OmnipodSettingsViewModel
+
+    var body: some View {
+        List {
+            NavigationLink(destination: ReadPodStatusView(toRun: viewModel.readPodStatus)) {
+                FrameworkLocalText("Read Pod Status", comment: "Text for read pod status navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: PlayTestBeepsView(toRun: viewModel.playTestBeeps)) {
+                FrameworkLocalText("Play Test Beeps", comment: "Text for play test beeps navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(!self.viewModel.podOk)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Pulse Log", comment: "Text for read pulse log title"),
+                actionString: LocalizedString("Reading Pulse Log...", comment: "Text for read pulse log action"),
+                failedString: LocalizedString("Failed to read pulse log.", comment: "Alert title for error when reading pulse log"),
+                toRun: viewModel.readPulseLog))
+            {
+                FrameworkLocalText("Read Pulse Log", comment: "Text for read pulse log navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Pulse Log Plus", comment: "Text for read pulse log plus title"),
+                actionString: LocalizedString("Reading Pulse Log Plus...", comment: "Text for read pulse log plus action"),
+                failedString: LocalizedString("Failed to read pulse log plus.", comment: "Alert title for error when reading pulse log plus"),
+                toRun: viewModel.readPulseLogPlus))
+            {
+                FrameworkLocalText("Read Pulse Log Plus", comment: "Text for read pulse log plus navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Activation Time", comment: "Text for read activation time title"),
+                actionString: LocalizedString("Reading Activation Time...", comment: "Text for read activation time action"),
+                failedString: LocalizedString("Failed to read activation time.", comment: "Alert title for error when reading activation time"),
+                toRun: self.viewModel.readActivationTime))
+            {
+                FrameworkLocalText("Read Activation Time", comment: "Text for read activation time navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: ReadPodInfoView(
+                title: LocalizedString("Read Triggered Alerts", comment: "Text for read triggered alerts title"),
+                actionString: LocalizedString("Reading Triggered Alerts...", comment: "Text for read triggered alerts action"),
+                failedString: LocalizedString("Failed to read triggered alerts.", comment: "Alert title for error when reading triggered alerts"),
+                toRun: self.viewModel.readTriggeredAlerts))
+            {
+                FrameworkLocalText("Read Triggered Alerts", comment: "Text for read triggered alerts navigation link")
+                    .foregroundColor(Color.primary)
+            }
+            .disabled(self.viewModel.noPod)
+
+            NavigationLink(destination: PumpManagerDetailsView(
+                toRun: self.viewModel.pumpManagerDetails))
+            {
+                FrameworkLocalText("Pump Manager Details", comment: "Text for pump manager details navigation link")
+                    .foregroundColor(Color.primary)
+            }
+        }
+        .insetGroupedListStyle()
+        .navigationBarTitle(title)
+    }
+}

--- a/OmniKitUI/Views/PodSetupView.swift
+++ b/OmniKitUI/Views/PodSetupView.swift
@@ -107,7 +107,7 @@ struct PodSetupView: View {
 
 }
 
-struct RileyLinkSetupView_Previews: PreviewProvider {
+struct PodSetupView_Previews: PreviewProvider {
     static var previews: some View {
         PodSetupView(nextAction: {}, allowDebugFeatures: true, skipOnboarding: {})
     }

--- a/OmniKitUI/Views/PumpManagerDetailsView.swift
+++ b/OmniKitUI/Views/PumpManagerDetailsView.swift
@@ -1,0 +1,104 @@
+//
+//  PumpManagerDetailsView.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 9/26/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+
+
+struct PumpManagerDetailsView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: String) -> Void) -> Void)?
+
+    private let title = LocalizedString("Pump Manager Details", comment: "navigation title for pump manager details")
+    private let actionString = LocalizedString("Retrieving Pump Manager Details...", comment: "button title when retrieving pump manager details")
+    private let buttonTitle = LocalizedString("Refresh Pump Manager Details", comment: "button title to refresh pump manager details")
+
+    @State private var displayString: String = ""
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    init(toRun: @escaping (_ completion: @escaping (_ result: String) -> Void) -> Void) {
+        self.toRun = toRun
+    }
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    let myFont = Font
+                        .system(size: 12)
+                        .monospaced()
+                    Text(self.displayString)
+                        .font(myFont)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                self.displayString = result
+                executing = false
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return buttonTitle
+        }
+    }
+}
+
+struct PumpManagerDetailsView_Previews: PreviewProvider {
+    static var previews: some View {
+        let examplePumpManagerDetails: String = "## OmnipodPumpManager\n\n## RileyLinkPumpManager\nlastTimerTick: 2023-10-07 22:35:39 +0000\n\n## RileyLinkDeviceManager\n\ncentral: <CBCentralManager: 0x283d877a0>\n\nautoConnectIDs: [\"F0178BCA-967D-504A-8C3A-99E84964B459\"]\n\ntimerTickEnabled: true\n\nidleListeningState: disabled\n\n## RileyLinkDevice\n* name: JPM OrangePro\n* lastIdle: 0001-01-01 00:00:00 +0000\n* isIdleListeningPending: false\n* isTimerTickEnabled: true\n* isTimerTickNotifying: true\n* radioFirmware: Optional(subg_rfspy 2.2)\n* bleFirmware: Optional(ble_rfspy 2.0)\n* peripheralManager: <RileyLinkBLEKit.PeripheralManager: 0x28272cee0>\n* sessionQueue.operationCount: 2\n\npodComms: ## PodComms\nconfiguredDevices: [\"F0178BCA-967D-504A-8C3A-99E84964B459\"]\ndelegate: true\n\nstatusObservers.count: 2\nstatus: ## PumpManagerStatus\n* timeZone: GMT-0700 (fixed)\n* device: <<HKDevice: 0x282cd6120>, name:Omnipod, manufacturer:Insulet, model:Eros, firmware:2.10.0, software:1.0, localIdentifier:1F05DD9A>\n* pumpBatteryChargeRemaining: nil\n* basalDeliveryState: Optional(LoopKit.PumpManagerStatus.BasalDeliveryState.active(2023-10-07 22:33:48 +0000))\n* bolusState: noBolus\n* insulinType: Optional(LoopKit.InsulinType.humalog)\n* deliveryIsUncertain: false\n\npodStateObservers.count: 1\nstate: ## OmnipodPumpManagerState\n* isOnboarded: true\n* timeZone: GMT-0700 (fixed)\n* basalSchedule: BasalSchedule(entries: [OmniKit.BasalScheduleEntry(rate: 0.9, startTime: 0.0)])\n* maximumTempBasalRate: 2.0\n* scheduledExpirationReminderOffset: Optional(\"24h0m\")\n* defaultExpirationReminderOffset: 24h0m\n* lowReservoirReminderValue: 50.0\n* podAttachmentConfirmed: true\n* activeAlerts: []\n* alertsWithPendingAcknowledgment: []\n* acknowledgedTimeOffsetAlert: false\n* initialConfigurationCompleted: true\n* unstoredDoses: []\n* suspendEngageState: stable\n* bolusEngageState: stable\n* tempBasalEngageState: stable\n* lastPumpDataReportDate: Optional(2023-10-07 22:35:24 +0000)\n* isPumpDataStale: false\n* silencePod: false\n* confirmationBeeps: manualCommands\n* pairingAttemptAddress: nil\n* insulinType: Optional(LoopKit.InsulinType.humalog)\n* scheduledExpirationReminderOffset: Optional(\"24h0m\")\n* defaultExpirationReminderOffset: 24h0m\n* rileyLinkBatteryAlertLevel: nil\n* lastRileyLinkBatteryAlertDate 0001-01-01 00:00:00 +0000\n* RileyLinkConnectionManagerState: RileyLinkConnectionState(autoConnectIDs: Set([\"F0178BCA-967D-504A-8C3A-99E84964B459\"]))\n* PodState: ### PodState\n* address: 1F05DD9A\n* activatedAt: Optional(2023-10-07 22:31:21 +0000)\n* expiresAt: Optional(2023-10-10 22:30:51 +0000)\n* timeActive: 4m\n* timeActiveUpdated: Optional(2023-10-07 22:35:38 +0000)\n* setupUnitsDelivered: Optional(2.65)\n* piVersion: 2.10.0\n* pmVersion: 2.10.0\n* lot: 72353\n* tid: 3280440\n* suspendState: resumed(2023-10-07 22:33:48 +0000)\n* unacknowledgedCommand: nil\n* unfinalizedBolus: nil\n* unfinalizedTempBasal: nil\n* unfinalizedSuspend: nil\n* unfinalizedResume: Optional(Resume: 10/7/23, 3:33:48 PM Certain)\n* finalizedDoses: []\n* activeAlertsSlots: No alerts\n* messageTransportState: MessageTransportState(packetNumber: 2, messageNumber: 8)\n* setupProgress: completed\n* primeFinishTime: Optional(2023-10-07 22:33:16 +0000)\n* configuredAlerts: [OmniKit.AlertSlot.slot4LowReservoir: Low reservoir, OmniKit.AlertSlot.slot3ExpirationReminder: Expiration reminder, OmniKit.AlertSlot.slot2ShutdownImminent: Shutdown imminent, OmniKit.AlertSlot.slot7Expired: Pod expired]\n* insulinType: humalog\n* PdmRef: nil\n* Fault: nil\n\n* PreviousPodState: nil\n"
+        NavigationView {
+            PumpManagerDetailsView() { completion in
+                completion(examplePumpManagerDetails)
+            }
+        }
+    }
+}

--- a/OmniKitUI/Views/ReadPodInfoView.swift
+++ b/OmniKitUI/Views/ReadPodInfoView.swift
@@ -1,0 +1,135 @@
+//
+//  ReadPodInfoView.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 11/25/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import OmniKit
+
+
+struct ReadPodInfoView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var title: String           // e.g., "Read Pulse Log"
+    var actionString: String    // e.g., "Reading Pulse Log..."
+    var failedString: String    // e.g., "Failed to read pulse log."
+
+    var toRun: ((_ completion: @escaping (_ result: Result<String, Error>) -> Void) -> Void)?
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var error: Error? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    let myFont = Font
+                        .system(size: 12)
+                        .monospaced()
+                    Text(self.displayString)
+                        .font(myFont)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                executing = false
+                switch result {
+                case .success(let resultString):
+                    self.displayString = resultString
+                case .failure(let error):
+                    self.displayString = ""
+                    self.error = error
+                    self.alertIsPresented = true
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+struct ReadPodInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ReadPodInfoView(
+                title: "Read Pulse Log",
+                actionString: "Reading Pulse Log...",
+                failedString: "Failed to read pulse log"
+            ) { completion in
+                let podInfoPulseLogRecent = try! PodInfoPulseLogRecent(encodedData: Data([0x50, 0x03, 0x17,
+                    0x39, 0x72, 0x58, 0x01,  0x3c, 0x72, 0x43, 0x01,  0x41, 0x72, 0x5a, 0x01,  0x44, 0x71, 0x47, 0x01,
+                    0x49, 0x51, 0x59, 0x01,  0x4c, 0x51, 0x44, 0x01,  0x51, 0x73, 0x59, 0x01,  0x54, 0x50, 0x43, 0x01,
+                    0x59, 0x50, 0x5a, 0x81,  0x5c, 0x51, 0x42, 0x81,  0x61, 0x73, 0x59, 0x81,  0x00, 0x75, 0x43, 0x80,
+                    0x05, 0x70, 0x5a, 0x80,  0x08, 0x50, 0x44, 0x80,  0x0d, 0x50, 0x5b, 0x80,  0x10, 0x75, 0x43, 0x80,
+                    0x15, 0x72, 0x5e, 0x80,  0x18, 0x73, 0x45, 0x80,  0x1d, 0x72, 0x5b, 0x00,  0x20, 0x70, 0x43, 0x00,
+                    0x25, 0x50, 0x5c, 0x00,  0x28, 0x50, 0x46, 0x00,  0x2d, 0x50, 0x5a, 0x00,  0x30, 0x75, 0x47, 0x00,
+                    0x35, 0x72, 0x59, 0x00,  0x38, 0x70, 0x46, 0x00,  0x3d, 0x75, 0x57, 0x00,  0x40, 0x72, 0x43, 0x00,
+                    0x45, 0x73, 0x55, 0x00,  0x48, 0x73, 0x41, 0x00,  0x4d, 0x70, 0x52, 0x00,  0x50, 0x73, 0x3f, 0x00,
+                    0x55, 0x74, 0x4d, 0x00,  0x58, 0x72, 0x3d, 0x80,  0x5d, 0x73, 0x4d, 0x80,  0x60, 0x71, 0x3d, 0x80,
+                    0x01, 0x51, 0x50, 0x80,  0x04, 0x72, 0x3d, 0x80,  0x09, 0x50, 0x4e, 0x80,  0x0c, 0x51, 0x40, 0x80,
+                    0x11, 0x74, 0x50, 0x80,  0x14, 0x71, 0x40, 0x80,  0x19, 0x50, 0x4d, 0x80,  0x1c, 0x75, 0x3f, 0x00,
+                    0x21, 0x72, 0x52, 0x00,  0x24, 0x72, 0x40, 0x00,  0x29, 0x71, 0x53, 0x00,  0x2c, 0x50, 0x42, 0x00,
+                    0x31, 0x51, 0x55, 0x00,  0x34, 0x50, 0x42, 0x00   ]))
+                let lastPulseNumber = Int(podInfoPulseLogRecent.indexLastEntry)
+                completion(.success(pulseLogString(pulseLogEntries: podInfoPulseLogRecent.pulseLog, lastPulseNumber: lastPulseNumber)))
+            }
+        }
+    }
+}

--- a/OmniKitUI/Views/ReadPodStatusView.swift
+++ b/OmniKitUI/Views/ReadPodStatusView.swift
@@ -1,0 +1,169 @@
+//
+//  ReadPodStatusView.swift
+//  OmniKit
+//
+//  Created by Joe Moran on 8/15/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
+//
+
+import SwiftUI
+import LoopKit
+import OmniKit
+
+
+struct ReadPodStatusView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+
+    var toRun: ((_ completion: @escaping (_ result: PumpManagerResult<DetailedStatus>) -> Void) -> Void)?
+
+    private let title = LocalizedString("Read Pod Status", comment: "navigation title for read pod status")
+    private let actionString = LocalizedString("Reading Pod Status...", comment: "button title when executing read pod status")
+    private let failedString = LocalizedString("Failed to read pod status.", comment: "Alert title for error when reading pod status")
+
+    @State private var alertIsPresented: Bool = false
+    @State private var displayString: String = ""
+    @State private var error: LocalizedError? = nil
+    @State private var executing: Bool = false
+    @State private var showActivityView: Bool = false
+
+    var body: some View {
+        VStack {
+            List {
+                Section {
+                    Text(self.displayString).fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        self.showActivityView = true
+                    }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }.sheet(isPresented: $showActivityView) {
+                ActivityView(isPresented: $showActivityView, activityItems: [self.displayString])
+            }
+            VStack {
+                Button(action: {
+                    asyncAction()
+                }) {
+                    Text(buttonText)
+                        .actionButtonStyle(.primary)
+                }
+                .padding()
+                .disabled(executing)
+            }
+            .padding(self.horizontalSizeClass == .regular ? .bottom : [])
+            .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
+        }
+        .insetGroupedListStyle()
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
+        .onFirstAppear {
+            asyncAction()
+        }
+    }
+
+    private func asyncAction () {
+        DispatchQueue.global(qos: .utility).async {
+            executing = true
+            self.displayString = ""
+            toRun?() { (result) in
+                executing = false
+                switch result {
+                case .success(let detailedStatus):
+                    self.displayString = podStatusString(status: detailedStatus)
+                case .failure(let error):
+                    self.error = error
+                    self.alertIsPresented = true
+                }
+            }
+        }
+    }
+
+    private var buttonText: String {
+        if executing {
+            return actionString
+        } else {
+            return title
+        }
+    }
+
+    private func alert(error: Error?) -> SwiftUI.Alert {
+        return SwiftUI.Alert(
+            title: Text(failedString),
+            message: Text(error?.localizedDescription ?? "No Error")
+        )
+    }
+}
+
+private func podStatusString(status: DetailedStatus) -> String {
+    var result, str: String
+
+    let formatter = DateComponentsFormatter()
+    formatter.unitsStyle = .full
+    formatter.allowedUnits = [.hour, .minute]
+    formatter.unitsStyle = .short
+    if let timeStr = formatter.string(from: status.timeActive) {
+        str = timeStr
+    } else {
+        str = String(format: LocalizedString("%1$@ minutes", comment: "The format string for minutes (1: number of minutes string)"), String(describing: Int(status.timeActive / 60)))
+    }
+    result = String(format: LocalizedString("Pod Active: %1$@", comment: "The format string for Pod Active: (1: formatted time)"), str)
+
+    result += String(format: LocalizedString("\nPod Progress: %1$@", comment: "The format string for Pod Progress: (1: pod progress string)"), String(describing: status.podProgressStatus))
+
+    result += String(format: LocalizedString("\nDelivery Status: %1$@", comment: "The format string for Delivery Status: (1: delivery status string)"), String(describing: status.deliveryStatus))
+
+    result += String(format: LocalizedString("\nLast Programming Seq Num: %1$@", comment: "The format string for last programming sequence number: (1: last programming sequence number)"), String(describing: status.lastProgrammingMessageSeqNum))
+
+    result += String(format: LocalizedString("\nBolus Not Delivered: %1$@ U", comment: "The format string for Bolus Not Delivered: (1: bolus not delivered string)"), status.bolusNotDelivered.twoDecimals)
+
+    result += String(format: LocalizedString("\nPulse Count: %1$d", comment: "The format string for Pulse Count (1: pulse count)"), Int(round(status.totalInsulinDelivered / Pod.pulseSize)))
+
+    result += String(format: LocalizedString("\nReservoir Level: %1$@ U", comment: "The format string for Reservoir Level: (1: reservoir level string)"), status.reservoirLevel == Pod.reservoirLevelAboveThresholdMagicNumber ? "50+" : status.reservoirLevel.twoDecimals)
+
+    result += String(format: LocalizedString("\nAlerts: %1$@", comment: "The format string for Alerts: (1: the alerts string)"), alertSetString(alertSet: status.unacknowledgedAlerts))
+
+    if status.radioRSSI != 0 {
+        result += String(format: LocalizedString("\nRSSI: %1$@", comment: "The format string for RSSI: (1: RSSI value)"), String(describing: status.radioRSSI))
+        result += String(format: LocalizedString("\nReceiver Low Gain: %1$@", comment: "The format string for receiverLowGain: (1: receiverLowGain)"), String(describing: status.receiverLowGain))
+    }
+
+    if status.faultEventCode.faultType != .noFaults {
+        // report the additional fault related information in a separate section
+        result += String(format: LocalizedString("\n\n⚠️ Critical Pod Fault %1$03d (0x%2$02X)", comment: "The format string for fault code in decimal and hex: (1: fault code for decimal display) (2: fault code for hex display)"), status.faultEventCode.rawValue, status.faultEventCode.rawValue)
+        result += String(format: "\n%1$@", status.faultEventCode.faultDescription)
+        if let faultEventTimeSinceActivation = status.faultEventTimeSinceActivation,
+           let faultTimeStr = formatter.string(from: faultEventTimeSinceActivation)
+        {
+            result += String(format: LocalizedString("\nFault Time: %1$@", comment: "The format string for fault time: (1: fault time string)"), faultTimeStr)
+        }
+        if let errorEventInfo = status.errorEventInfo {
+            result += String(format: LocalizedString("\nFault Event Info: %1$03d (0x%2$02X),", comment: "The format string for fault event info: (1: fault event info)"), errorEventInfo.rawValue, errorEventInfo.rawValue)
+            result += String(format: LocalizedString("\n  Insulin State Table Corrupted: %@", comment: "The format string for insulin state table corrupted: (1: insulin state corrupted)"), String(describing: errorEventInfo.insulinStateTableCorruption))
+            result += String(format: LocalizedString("\n  Occlusion Type: %1$@", comment: "The format string for occlusion type: (1: occlusion type)"), String(describing: errorEventInfo.occlusionType))
+            result += String(format: LocalizedString("\n  Immediate Bolus In Progress: %1$@", comment: "The format string for immediate bolus in progress: (1: immediate bolus in progress)"), String(describing: errorEventInfo.immediateBolusInProgress))
+            result += String(format: LocalizedString("\n  Previous Pod Progress: %1$@", comment: "The format string for previous pod progress: (1: previous pod progress string)"), String(describing: errorEventInfo.podProgressStatus))
+        }
+        if let pdmRef = status.pdmRef {
+            result += String(format: LocalizedString("\nRef: %@", comment: "The Ref format string (1: pdm ref string)"), pdmRef)
+        }
+    }
+
+    return result
+}
+
+struct ReadPodStatusView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            let detailedStatus = try! DetailedStatus(encodedData: Data([0x02, 0x0d, 0x00, 0x00, 0x00, 0x0e, 0x00, 0xc3, 0x6a, 0x02, 0x07, 0x03, 0xff, 0x02, 0x09, 0x20, 0x00, 0x28, 0x99, 0x08, 0x00, 0x82]))
+            ReadPodStatusView() { completion in
+                completion(.success(detailedStatus))
+            }
+        }
+    }
+}

--- a/OmniKitUI/Views/SilencePodSelectionView.swift
+++ b/OmniKitUI/Views/SilencePodSelectionView.swift
@@ -1,9 +1,9 @@
 //
-//  BeepPreferenceSelectionView.swift
+//  SilencePodSelectionView.swift
 //  OmniKit
 //
-//  Created by Pete Schwamb on 2/14/22.
-//  Copyright © 2022 LoopKit Authors. All rights reserved.
+//  Created by Joe Moran 8/30/23.
+//  Copyright © 2023 LoopKit Authors. All rights reserved.
 //
 
 import SwiftUI
@@ -11,21 +11,21 @@ import LoopKit
 import LoopKitUI
 import OmniKit
 
-struct BeepPreferenceSelectionView: View {
+struct SilencePodSelectionView: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
-    private var initialValue: BeepPreference
-    @State private var preference: BeepPreference
-    private var onSave: ((_ selectedValue: BeepPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void)?
+    private var initialValue: SilencePodPreference
+    @State private var preference: SilencePodPreference
+    private var onSave: ((_ selectedValue: SilencePodPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void)?
 
     @State private var alertIsPresented: Bool = false
     @State private var error: LocalizedError?
     @State private var saving: Bool = false
 
 
-    init(initialValue: BeepPreference, onSave: @escaping (_ selectedValue: BeepPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void) {
+    init(initialValue: SilencePodPreference, onSave: @escaping (_ selectedValue: SilencePodPreference, _ completion: @escaping (_ error: LocalizedError?) -> Void) -> Void) {
         self.initialValue = initialValue
         self._preference = State(initialValue: initialValue)
         self.onSave = onSave
@@ -39,12 +39,11 @@ struct BeepPreferenceSelectionView: View {
         VStack {
             List {
                 Section {
-                    Text(LocalizedString("Confidence reminders are beeps from the Pod which can be used to acknowledge selected commands when the Pod is not silenced.", comment: "Help text for BeepPreferenceSelectionView")).fixedSize(horizontal: false, vertical: true)
+                    Text(LocalizedString("Silence Pod mode suppresses all Pod alert and confirmation reminder beeping.", comment: "Help text for Silence Pod view")).fixedSize(horizontal: false, vertical: true)
                         .padding(.vertical, 10)
                 }
-
                 Section {
-                    ForEach(BeepPreference.allCases, id: \.self) { preference in
+                    ForEach(SilencePodPreference.allCases, id: \.self) { preference in
                         HStack {
                             CheckmarkListItem(
                                 title: Text(preference.title),
@@ -85,10 +84,9 @@ struct BeepPreferenceSelectionView: View {
             }
             .padding(self.horizontalSizeClass == .regular ? .bottom : [])
             .background(Color(UIColor.secondarySystemGroupedBackground).shadow(radius: 5))
-
         }
         .insetGroupedListStyle()
-        .navigationTitle(LocalizedString("Confidence Reminders", comment: "navigation title for confidence reminders"))
+        .navigationTitle(LocalizedString("Silence Pod", comment: "navigation title for Silnce Pod"))
         .navigationBarTitleDisplayMode(.inline)
         .alert(isPresented: $alertIsPresented, content: { alert(error: error) })
     }
@@ -110,15 +108,15 @@ struct BeepPreferenceSelectionView: View {
 
     private var cancelButton: some View {
         Button(action: { self.presentationMode.wrappedValue.dismiss() } ) {
-            Text(LocalizedString("Cancel", comment: "Button title for cancelling confidence reminders edit"))
+            Text(LocalizedString("Cancel", comment: "Button title for cancelling silence pod edit"))
         }
     }
 
     var saveButtonText: String {
         if saving {
-            return LocalizedString("Saving...", comment: "button title for saving confidence reminder while saving")
+            return LocalizedString("Saving...", comment: "button title for saving silence pod preference while saving")
         } else {
-            return LocalizedString("Save", comment: "button title for saving confidence reminder")
+            return LocalizedString("Save", comment: "button title for saving silence pod preference")
         }
     }
 
@@ -128,17 +126,16 @@ struct BeepPreferenceSelectionView: View {
 
     private func alert(error: Error?) -> SwiftUI.Alert {
         return SwiftUI.Alert(
-            title: Text(LocalizedString("Failed to update confidence reminder preference.", comment: "Alert title for error when updating confidence reminder preference")),
+            title: Text(LocalizedString("Failed to update silence pod preference.", comment: "Alert title for error when updating silence pod preference")),
             message: Text(error?.localizedDescription ?? "No Error")
         )
     }
-
 }
 
-struct BeepPreferenceSelectionView_Previews: PreviewProvider {
+struct SilencePodSelectionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            BeepPreferenceSelectionView(initialValue: .extended) { selectedValue, completion in
+            SilencePodSelectionView(initialValue: .disabled) { selectedValue, completion in
                 print("Selected: \(selectedValue)")
                 completion(nil)
             }

--- a/OmniKitUI/Views/UncertaintyRecoveredView.swift
+++ b/OmniKitUI/Views/UncertaintyRecoveredView.swift
@@ -16,9 +16,8 @@ struct UncertaintyRecoveredView: View {
     
     var body: some View {
         GuidePage(content: {
-            Text(LocalizedString("Loop has recovered communication with the pod on your body.\n\nInsulin delivery records have been updated and should match what has actually been delivered.\n\nYou may continue to use Loop normally now.", comment: "Text body for page showing insulin uncertainty has been recovered."))
-                .fixedSize(horizontal: false, vertical: true)
-                .padding([.top, .bottom])
+            Text(String(format: LocalizedString("%1$@ has recovered communication with the pod on your body.\n\nInsulin delivery records have been updated and should match what has actually been delivered.\n\nYou may continue to use %2$@ normally now.", comment: "Text body for page showing insulin uncertainty has been recovered (1: appName) (2: appName)"), self.appName, self.appName))
+               .padding([.top, .bottom])
         }) {
             VStack {
                 Button(action: {


### PR DESCRIPTION
This PR adds the Silent Pod and Pod Diagnostics features to the Omnipod screen for Eros pods:
* Prerequisite: LoopKit pull requests, OmniKit PR 28, 29, 30 and 31 should be merged first

The Silent Pod and Pod Diagnostics rows are only visible when allowDebugFeatures is true. This is configured using build-time flags in LoopWorkspace and is true by default for DIY Loop.

User-facing changes:
* Pod notifications include an option to silence the pod
   * When silenced, alerts are only on the phone, the pod does not beep
   * Pod faults, end of life and out of insulin still alarm on the pod regardless of this setting
* The previous pod row is moved under the pod details row to make it easier to find
* A pod diagnostics row is added to the end of the pod screen
   * various diagnostics rows are added in a new sub-screen

![lnl-omnikit-pr-6](https://github.com/loopandlearn/OmniKit/assets/19607791/a71d622f-0873-4ce6-872b-23a2266b019a)

